### PR TITLE
ENH: add iocmanager loader

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,7 +1,9 @@
 <template>
   <ul>
     <li>
-      <router-link to="/whatrec">WhatRec?</router-link>
+      <router-link to="/">Records</router-link>
+      &nbsp;
+      <router-link to="/iocs/*/">IOCs</router-link>
     </li>
   </ul>
   <br/>

--- a/src/whatrecord/bin/iocmanager_loader.py
+++ b/src/whatrecord/bin/iocmanager_loader.py
@@ -1,0 +1,120 @@
+"""
+"whatrec iocmanager_loader" is used to import IOC lists from SLAC's IocManager
+configuration files.
+"""
+
+import argparse
+import ast
+import json
+import logging
+import os
+import re
+from typing import Dict, List
+
+logger = logging.getLogger(__name__)
+DESCRIPTION = __doc__
+
+KEY_RE = re.compile(r'([a-z_]+)\s*:', re.IGNORECASE)
+
+
+def build_arg_parser(parser=None):
+    if parser is None:
+        parser = argparse.ArgumentParser()
+
+    parser.description = DESCRIPTION
+    parser.formatter_class = argparse.RawTextHelpFormatter
+
+    parser.add_argument(
+        '--configs',
+        type=str,
+        nargs='+',
+        help="Configuration file location(s)"
+    )
+
+    return parser
+
+
+def parse_config(lines) -> List[Dict[str, str]]:
+    """Parse an IOC manager config to get its IOCs."""
+    entries = []
+    loading = False
+    entry = None
+
+    for line in lines:
+        if 'procmgr_config' in line:
+            loading = True
+            continue
+        if not loading:
+            continue
+        if 'id:' in line:
+            if '}' in line:
+                entries.append(line)
+            else:
+                entry = line
+        elif entry is not None:
+            entry += line
+            if '}' in entry:
+                entries.append(entry)
+                entry = None
+
+    result = []
+    for entry in entries:
+        result.append(
+            ast.literal_eval(KEY_RE.sub(r'"\1":', entry.strip(', \t')))
+        )
+    return result
+
+
+def load_config_file(fn) -> List[Dict[str, str]]:
+    """
+    Load a configuration file and return the IOCs it contains.
+
+    Parameters
+    ----------
+    fn : str or pathlib.Path
+        The configuration filename
+    """
+    with open(fn, 'rt') as f:
+        lines = f.read().splitlines()
+
+    return parse_config(lines)
+
+
+def find_stcmd(directory: str, ioc_id: str) -> str:
+    """Find the startup script st.cmd for a given IOC."""
+    if directory.startswith("ioc"):
+        directory = os.path.join("/reg/g/pcds/epics", directory)
+
+    # Templated IOCs are... different:
+    build_path = os.path.join(directory, "build", "iocBoot", ioc_id)
+    if os.path.exists(build_path):
+        return os.path.join(build_path, "st.cmd")
+
+    # Otherwise, it should be straightforward:
+    return os.path.join(directory, "iocBoot", ioc_id, "st.cmd")
+
+
+def main(configs):
+    iocs = [
+        ioc
+        for fn in (configs or [])
+        for ioc in load_config_file(fn)
+    ]
+
+    iocs.sort(key=lambda ioc: ioc.get("host", '?'))
+
+    for ioc_info in iocs:
+        directory = ioc_info.get("dir", None)
+        # disable = ioc_info.get("disable", False)
+        if not directory:
+            continue
+        ioc_id = ioc_info.get("id", None)
+        stcmd = find_stcmd(directory, ioc_id)
+        ioc_info["startup_script"] = stcmd
+        # if os.path.exists(stcmd):
+        #     ioc_info["startup_script"] = stcmd
+        # elif not disable:
+        #     # print("missing stcmd", stcmd, ioc_info)
+        #     ...
+
+    print(json.dumps(iocs, indent=4))

--- a/src/whatrecord/bin/main.py
+++ b/src/whatrecord/bin/main.py
@@ -14,7 +14,7 @@ import whatrecord  # noqa
 DESCRIPTION = __doc__
 
 
-MODULES = ("server", )  # , "api", "pv")
+MODULES = ("server", "iocmanager_loader")  # , "api", "pv")
 
 
 def _try_import(module):
@@ -77,7 +77,7 @@ def main():
 
     subparsers = top_parser.add_subparsers(help="Possible subcommands")
     for command_name, (build_func, main) in COMMANDS.items():
-        sub = subparsers.add_parser(command_name)
+        sub = subparsers.add_parser(command_name.replace("_", "-"))
         build_func(sub)
         sub.set_defaults(func=main)
 


### PR DESCRIPTION
First part of #20 for LCLS's purposes.

```
$ whatrec iocmanager-loader --configs iocmanager.example.cfg |head -n 15
[
    {
        "id": "ioc-amo-gige-01",
        "host": "ioc-amo-gige01",
        "port": 30011,
        "dir": "ioc/amo/gigECam/R2.3.3",
        "history": [
            "ioc/amo/gigECam/R2.3.3",
            "/reg/neh/home/sstubbs/work/amo/gigECam/current"
        ],
        "startup_script": "/reg/g/pcds/epics/ioc/amo/gigECam/R2.3.3/iocBoot/ioc-amo-gige-01/st.cmd"
    },
...
```

The original utility (which we can't import as it's not a package) uses some [unsavory techniques](https://github.com/pcdshub/IocManager/blob/39a284dbf41d84f743d78e994654f160c1337383/utils.py#L496) for loading the configs.

The parser here is less resilient and dynamic, but as the author of it, I like it a bit more than the above. Can revisit if need be.