### PR TITLE
FIX: forwardref issue with python 3.7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Not yet. But I'm thinking of trying mkdocs for fun.
 Requirements
 ------------
 
-* Python 3.9+
+* Python 3.7+
 * aiohttp
 * apischema[graphql]
 * cython

--- a/whatrecord/common.py
+++ b/whatrecord/common.py
@@ -38,7 +38,6 @@ def _load_context_from_tuple(items: Tuple[str, int]) -> LoadContext:
 
 FullLoadContext = Tuple[LoadContext, ...]
 IocInfoDict = Dict[str, Union[str, Dict[str, str], List[str]]]
-AnyField = Union["RecordField", "PVAFieldReference"]
 
 
 @dataclass(repr=False)
@@ -289,6 +288,9 @@ PVAFieldReference: {{ record_name }}.{{ field_name }}
                  - {{ metadata }}
 """,
     }
+
+
+AnyField = Union[RecordField, PVAFieldReference]
 
 
 @dataclass

--- a/whatrecord/db.py
+++ b/whatrecord/db.py
@@ -355,6 +355,12 @@ class _DatabaseTransformer(lark.visitors.Transformer_InPlaceRecursive):
             context=_context_from_token(self.fn, value),
         )
 
+    def json_array(self, elements):
+        return elements
+
+    def json_elements(self, elements):
+        return elements
+
     recordtype_field_item_menu = recordtype_field_item
 
     def cdef(self, cdef_text):

--- a/whatrecord/db.py
+++ b/whatrecord/db.py
@@ -355,10 +355,10 @@ class _DatabaseTransformer(lark.visitors.Transformer_InPlaceRecursive):
             context=_context_from_token(self.fn, value),
         )
 
-    def json_array(self, elements):
-        return elements
+    def json_array(self, elements=None):
+        return elements or []
 
-    def json_elements(self, elements):
+    def json_elements(self, *elements):
         return elements
 
     recordtype_field_item_menu = recordtype_field_item

--- a/whatrecord/format.py
+++ b/whatrecord/format.py
@@ -8,6 +8,13 @@ import jinja2
 logger = logging.getLogger(__name__)
 
 
+pass_eval_context = (
+    jinja2.pass_eval_context
+    if hasattr(jinja2, "pass_eval_context")
+    else jinja2.evalcontextfilter
+)
+
+
 class FormatContext:
     def __init__(
         self, helpers=None, *, trim_blocks=True, lstrip_blocks=True, **env_kwargs
@@ -28,17 +35,17 @@ class FormatContext:
     def get_filters(self, **user_config):
         """All jinja filters."""
 
-        @jinja2.evalcontextfilter
+        @pass_eval_context
         def title_fill(eval_ctx, text, fill_char):
             return fill_char * len(text)
 
-        @jinja2.evalcontextfilter
+        @pass_eval_context
         def classname(eval_ctx, obj):
             if inspect.isclass(obj):
                 return obj.__name__
             return type(obj).__name__
 
-        @jinja2.evalcontextfilter
+        @pass_eval_context
         def render_object(eval_ctx, obj, option):
             return self.render_object(obj, option)
 

--- a/whatrecord/server/server.py
+++ b/whatrecord/server/server.py
@@ -108,7 +108,9 @@ class ServerState:
             if not instance.is_pva:
                 # For now, V3 only
                 instance.metadata["archived"] = instance.name in self.archived_pvs
-                instance.metadata["gateway"] = self.get_gateway_info(instance.name)
+                instance.metadata["gateway"] = apischema.serialize(
+                    self.get_gateway_info(instance.name)
+                )
         return whatrec
 
     def whatrec(self, pvname) -> List[WhatRecord]:

--- a/whatrecord/tests/conftest.py
+++ b/whatrecord/tests/conftest.py
@@ -1,0 +1,19 @@
+import pathlib
+
+import pytest
+
+MODULE_PATH = pathlib.Path(__file__).resolve().parent
+
+STARTUP_SCRIPTS = list((MODULE_PATH / "iocs").glob("**/st.cmd"))
+
+
+startup_scripts = pytest.mark.parametrize(
+    "startup_script",
+    [
+        pytest.param(
+            startup_script,
+            id="/".join(startup_script.parts[-2:])
+        )
+        for startup_script in STARTUP_SCRIPTS
+    ]
+)

--- a/whatrecord/tests/test_bin_parse.py
+++ b/whatrecord/tests/test_bin_parse.py
@@ -1,0 +1,23 @@
+"""Smoke tests to see if the provided IOCs load without crashing."""
+
+import pytest
+
+from ..bin.parse import main, parse
+from . import conftest
+
+
+@conftest.startup_scripts
+def test_load_smoke(startup_script):
+    parse(startup_script)
+
+
+@conftest.startup_scripts
+@pytest.mark.parametrize(
+    "as_json",
+    [
+        pytest.param(False, id="formatted"),
+        pytest.param(True, id="json"),
+    ]
+)
+def test_load_dump(startup_script, as_json):
+    main(startup_script, as_json=as_json)


### PR DESCRIPTION
Closes #34 
Partially addresses #23 

Ended up really being a `typing.Union[ForwardRef, ForwardRef]` issue with how it's handled in 3.7 vs 3.9 (and - I think - `from __future__ import annotations`, but to be honest I didn't dig much).

And it was easy enough to just rearrange the code to remove the forward reference.

Can add pypy3 to the test matrix one day