### PR TITLE
ENH: Happi + sketch of what a server plugin might look like

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -12,13 +12,19 @@ export default {
     TabMenu,
   },
   data() {
-    return {
-      tab_menu_items: [
-        {label: 'Records', icon: 'pi pi-fw pi-tags', to: '/'},
-        {label: 'IOCs', icon: 'pi pi-fw pi-sitemap', to: '/iocs'},
-      ]
+    let tab_menu_items = [
+      {label: 'Records', icon: 'pi pi-fw pi-tags', to: '/'},
+      {label: 'IOCs', icon: 'pi pi-fw pi-sitemap', to: '/iocs'},
+    ]
+    for (const plugin of ["happi", ]) {
+      tab_menu_items.push(
+        {label: plugin, icon: 'pi pi-fw pi-info-circle', to: '/' + plugin},
+      );
     }
-  }
+    return {
+      tab_menu_items: tab_menu_items
+    }
+  },
 
 };
 </script>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -5,6 +5,7 @@
 
 <script>
 import TabMenu from 'primevue/tabmenu';
+import { plugins } from "./settings.js";
 
 export default {
   name: "App",
@@ -16,7 +17,7 @@ export default {
       {label: 'Records', icon: 'pi pi-fw pi-tags', to: '/'},
       {label: 'IOCs', icon: 'pi pi-fw pi-sitemap', to: '/iocs'},
     ]
-    for (const plugin of ["happi", ]) {
+    for (const plugin of plugins) {
       tab_menu_items.push(
         {label: plugin, icon: 'pi pi-fw pi-info-circle', to: '/' + plugin},
       );

--- a/frontend/src/components/recordinfo.vue
+++ b/frontend/src/components/recordinfo.vue
@@ -17,7 +17,12 @@
       <template v-for="plugin_name in plugins" :key="plugin_name">
         <template v-for="plugin_match in instance.metadata[plugin_name] || []" :key="plugin_match.name">
           <details>
-            <summary>{{ plugin_name }} - {{ plugin_match.name }}</summary>
+            <summary>
+              {{ plugin_name }} - {{ plugin_match.name }}
+              <router-link :to="`/${plugin_name}/${plugin_match.name}`">
+                (Details)
+              </router-link>
+            </summary>
             <dictionary-table
               :dict="plugin_match"
               :cls="'metadata'"

--- a/frontend/src/components/recordinfo.vue
+++ b/frontend/src/components/recordinfo.vue
@@ -13,7 +13,22 @@
         :is_grecord=instance.is_grecord
         :is_pva=instance.is_pva
       />
+
+      <template v-for="plugin_name in plugins" :key="plugin_name">
+        <template v-for="plugin_match in instance.metadata[plugin_name] || []" :key="plugin_match.name">
+          <details>
+            <summary>{{ plugin_name }} - {{ plugin_match.name }}</summary>
+            <dictionary-table
+              :dict="plugin_match"
+              :cls="'metadata'"
+              :skip_keys="[]"
+              />
+          </details>
+          <br />
+        </template>
+      </template>
     </template>
+
   </template>
 
   <Accordion :multiple="true">
@@ -88,6 +103,8 @@ import ScriptContextLink from './script-context-link.vue'
 import Accordion from 'primevue/accordion';
 import AccordionTab from 'primevue/accordiontab';
 
+import { plugins } from '../settings.js';
+
 
 export default {
   name: 'Recordinfo',
@@ -138,6 +155,15 @@ export default {
       }
       return null;
     },
+    happi_metadata() {
+      if (this.instance_v3 == null) {
+        return [];
+      }
+      return this.instance_v3.metadata["happi"] || [];
+    },
+    plugins() {
+      return plugins;
+    }
   }
 }
 </script>

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -3,8 +3,12 @@ import * as VueRouter from 'vue-router';
 import WhatRec from './views/whatrec.vue';
 import ScriptView from './views/script-view.vue';
 import IocView from './views/iocs.vue';
+import HappiView from './views/happi.vue';
 
-const routes = [
+import { happi_enabled } from './settings.js';
+
+
+let routes = [
   {
       path: '/',
       redirect: '/whatrec/*/'
@@ -45,7 +49,25 @@ const routes = [
   },
 ]
 
+if (happi_enabled) {
+    routes.push(
+        {
+            name: 'happi',
+            path: '/happi/:item_name?',
+            component: HappiView,
+            props: route => (
+                {
+                    item_name: route.params.item_name || null,
+                }
+            )
+        },
+    )
+}
+
 export const router = VueRouter.createRouter({
   history: VueRouter.createWebHistory(),
   routes: routes,
+  scrollBehavior() {
+    document.getElementById('app').scrollIntoView();
+  }
 })

--- a/frontend/src/settings.js
+++ b/frontend/src/settings.js
@@ -1,0 +1,2 @@
+export const plugins = (process.env.VUE_APP_WHATRECORD_PLUGINS || "happi").split(" ");
+export const happi_enabled = plugins.indexOf("happi") >= 0;

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -9,6 +9,7 @@ export const store = createStore({
       record_glob: "*",
       glob_to_pvs: {},
       record_info: {},
+      plugin_info: {},
       ioc_info: [],
       selected_records: [],
       ioc_to_records: {},
@@ -35,6 +36,9 @@ export const store = createStore({
     set_ioc_info (state, { ioc_info }) {
       state.ioc_info = ioc_info;
     },
+    set_plugin_info (state, { plugin_info }) {
+      state.plugin_info = plugin_info;
+    },
     add_record_info (state, { record, info}) {
       console.debug("Adding record info", record, info);
       state.record_info[record] = info;
@@ -55,6 +59,18 @@ export const store = createStore({
         await commit("start_query");
         const response = await axios.get(`/api/iocs/*/matches`, {})
         await commit("set_ioc_info", {ioc_info: response.data.matches});
+      } catch (error) {
+        console.error(error);
+      } finally {
+        await commit("end_query");
+      }
+    },
+
+    async update_plugin_info ({commit}) {
+      try {
+        await commit("start_query");
+        const response = await axios.get(`/api/plugin/info`, {})
+        await commit("set_plugin_info", {plugin_info: response.data});
       } catch (error) {
         console.error(error);
       } finally {

--- a/frontend/src/views/happi.vue
+++ b/frontend/src/views/happi.vue
@@ -1,0 +1,142 @@
+<template>
+  <template v-if="item_name">
+    <h2>{{ item_name }} - Metadata</h2>
+    <dictionary-table
+      :dict="happi_item_info"
+      :cls="'metadata'"
+      :skip_keys="[]"
+      />
+
+    <h2>{{ item_name }} - Related Records</h2>
+    <ol>
+      <template v-for="record in happi_item_related_records" :key="record">
+        <li>
+          <router-link :to="`/whatrec/${record}/${record}`">{{record}}</router-link>
+        </li>
+      </template>
+    </ol>
+  </template>
+  <template v-else>
+    <DataTable
+        id="happi_table"
+        :value="happi_items"
+        dataKey="name"
+        filterDisplay="row"
+        v-model:filters="filters"
+        :globalFilterFields="['name', 'beamline', 'device_class', 'prefix']"
+    >
+      <template #header>
+        <div class="p-d-flex p-jc-between">
+          <Button type="button" icon="pi pi-filter-slash" label="Clear" class="p-button-outlined" @click="clear_filters()"/>
+          <span class="p-input-icon-left">
+            <i class="pi pi-search" />
+            <InputText v-model="filters['global'].value" placeholder="Search" />
+          </span>
+        </div>
+      </template>
+      <Column field="name" header="Name">
+        <template #body="{data}">
+          <router-link :to="`/happi/${data.name}`">{{data.name}}</router-link>
+        </template>
+      </Column>
+      <Column field="device_class" header="Class" />
+      <Column field="beamline" header="Beamline" />
+      <Column field="prefix" header="Prefix">
+        <template #body="{data}">
+          <router-link :to="`/whatrec/${data.prefix}*/${data.prefix}`">{{data.prefix}}</router-link>
+        </template>
+      </Column>
+      <Column field="stand" header="Stand" />
+      <Column field="active" header="Active" />
+    </DataTable>
+  </template>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+
+import Button from 'primevue/button';
+import Column from 'primevue/column';
+import DataTable from 'primevue/datatable';
+// import Dropdown from 'primevue/dropdown';
+import InputText from 'primevue/inputtext';
+import {FilterMatchMode} from 'primevue/api';
+
+import DictionaryTable from '../components/dictionary-table.vue'
+
+export default {
+  name: 'HappiView',
+  components: {
+    Button,
+    Column,
+    DataTable,
+    DictionaryTable,
+    // Dropdown,
+    InputText,
+  },
+  props: {
+    item_name: String,
+  },
+  data() {
+    return {
+      filters: null,
+    }
+  },
+  computed: {
+    happi_item_related_records () {
+      if (!this.item_name || !this.happi_items || !this.happi_info.metadata.item_to_records) {
+        return [];
+      }
+      return this.happi_info.metadata.item_to_records[this.item_name];
+    },
+    happi_item_info () {
+      if (!this.item_name || !this.happi_items) {
+        return {
+          "error": "Unknown item name",
+        };
+      }
+      return this.happi_info.metadata.item_to_metadata[this.item_name];
+    },
+    happi_items () {
+      if (!this.happi_info) {
+        return [];
+      }
+      return Object.values(this.happi_info.metadata.item_to_metadata);
+    },
+
+    ...mapState({
+      happi_info (state) {
+        if (!state.plugin_info) {
+          return {};
+        }
+        const happi_info = state.plugin_info.happi || {
+            metadata: {item_to_metadata: [], item_name_to_records: []}
+          };
+        return happi_info;
+      },
+    }),
+  },
+  created() {
+    this.init_filters();
+  },
+  mounted() {
+    this.$store.dispatch("update_plugin_info");
+    console.log("item name", this.item_name);
+  },
+  methods: {
+    init_filters() {
+      this.filters = {
+        'global': {value: "", matchMode: FilterMatchMode.CONTAINS},
+      };
+    },
+    clear_filters() {
+      this.init_filters();
+    },
+
+  },
+
+}
+</script>
+
+<style>
+</style>

--- a/frontend/src/views/iocs.vue
+++ b/frontend/src/views/iocs.vue
@@ -67,7 +67,7 @@
 </template>
 
 <script>
-import { mapState } from 'vuex'
+import { mapState } from 'vuex';
 
 import Button from 'primevue/button';
 import Column from 'primevue/column';

--- a/whatrecord/ioc_finder.py
+++ b/whatrecord/ioc_finder.py
@@ -1,39 +1,13 @@
-import asyncio
 import dataclasses
-import json
 import logging
 import pathlib
 from dataclasses import InitVar, field
 from typing import Dict, List, Union
 
-from whatrecord.common import IocInfoDict, IocMetadata
+from .common import IocInfoDict, IocMetadata
+from .util import run_script_with_json_output
 
 logger = logging.getLogger(__name__)
-
-
-async def load_from_external_script(script_line: str) -> List[IocInfoDict]:
-    """Run a script and get its JSON output."""
-    proc = await asyncio.create_subprocess_shell(
-        script_line,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE
-    )
-
-    (stdout, stderr) = await proc.communicate()
-    if stderr:
-        logger.warning(
-            "Standard error output while updating IOCs (%r): %s",
-            script_line, stderr
-        )
-
-    if stdout:
-        return json.loads(stdout.decode("utf-8"))
-
-    logger.warning(
-        "No standard output while updating IOCs (%r)",
-        script_line
-    )
-    return []
 
 
 class _IocInfoFinder:
@@ -50,7 +24,8 @@ class IocScriptExternalLoader(_IocInfoFinder):
     scripts: Dict[pathlib.Path, IocMetadata] = field(default_factory=dict)
 
     async def update(self):
-        for info in await load_from_external_script(self.load_script):
+        result = await run_script_with_json_output(self.load_script)
+        for info in (result or {}):
             self.add_or_update_entry(IocMetadata.from_dict(info))
         return await super().update()
 

--- a/whatrecord/plugins/happi.py
+++ b/whatrecord/plugins/happi.py
@@ -1,0 +1,348 @@
+"""
+happi whatrecord plugin
+
+Match your happi devices to IOCs and records.
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import dataclasses
+import fnmatch
+import json
+import logging
+import typing
+from typing import Any, Dict, Generator, List, Tuple, TypeVar, Union
+
+import apischema
+
+try:
+    import happi
+    import ophyd
+    from ophyd.signal import EpicsSignalBase
+except ImportError as ex:
+    raise ImportError(f"Dependency required for happi plugin unavailable: {ex}")
+
+
+logger = logging.getLogger(__name__)
+
+# Stash the description for later usage by the CLI interface.
+DESCRIPTION = __doc__.strip()
+CriteriaDict = Dict[str, Union[float, str]]
+T = TypeVar("T")
+
+
+HappiItem = Dict[str, Union[str, List[str], Dict[str, str]]]  # kinda...
+
+# TODO: this can be improved
+SIGNAL_CLASSES = (
+    EpicsSignalBase,
+    ophyd.EpicsMotor,
+    ophyd.EpicsScaler,
+    ophyd.EpicsMCA
+)
+
+
+@dataclasses.dataclass
+class PluginResults:
+    files_to_monitor: List[str]
+    metadata: Any
+    record_to_metadata: Dict[str, Any]
+    # defines records?
+
+
+@dataclasses.dataclass
+class HappiPluginResults:
+    item_to_metadata: Dict[str, HappiItem]
+    record_to_item_name: Dict[str, List[str]]
+    item_to_records: Dict[str, List[str]]
+
+
+def get_all_devices(
+    client: happi.Client = None,
+) -> Generator[ophyd.Device, None, None]:
+    """
+    Get all devices from a given happi client.
+
+    Parameters
+    ----------
+    client : happi.Client, optional
+        The happi client to use.  Defaults to using one from the environment
+        configuration.
+
+    Yields
+    ------
+    ophyd.Device
+    """
+    if client is None:
+        client = happi.Client.from_config()
+
+    for dev in client:
+        try:
+            obj = client[dev].get()
+        except Exception:
+            logger.exception("Failed to instantiate device: %s", dev)
+        else:
+            yield obj
+
+
+def get_devices_by_criteria(
+    search_criteria: CriteriaDict,
+    *,
+    client: happi.Client = None,
+    regex: bool = True,
+) -> Generator[ophyd.Device, None, None]:
+    """
+    Get all devices from a given happi client.
+
+    Parameters
+    ----------
+    search_criteria : dict
+        Dictionary of ``{'happi_key': 'search_value'}``.
+
+    client : happi.Client, optional
+        The happi client to use.  Defaults to using one from the environment
+        configuration.
+
+    Yields
+    ------
+    ophyd.Device
+    """
+    if client is None:
+        client = happi.Client.from_config()
+
+    search_method = client.search_regex if regex else client.search
+    for item in search_method(**search_criteria):
+        try:
+            obj = item.get()
+        except Exception:
+            logger.exception("Failed to instantiate device: %s", obj)
+        else:
+            yield obj
+
+
+def get_components_matching(
+    obj: ophyd.Device,
+    predicate: callable,
+) -> Generator[ophyd.ophydobj.OphydObject, None, None]:
+    """
+    Find signals of a specific type from a given ophyd Device.
+
+    Parameters
+    ----------
+    obj : ophyd.Device
+        The ophyd Device.
+
+    predicate : callable
+        Callable that should return True on a match.
+
+    Yields
+    ------
+    obj : ophyd.ophydobj.OphydObject
+    """
+    for name, dev in obj.walk_subdevices(include_lazy=True):
+        try:
+            included = predicate(dev)
+        except Exception:
+            logger.exception("Failed to check predicate against %s %s", name, dev)
+        else:
+            if included:
+                yield dev
+
+    for walk in obj.walk_signals(include_lazy=True):
+        try:
+            included = predicate(walk.item)
+        except Exception:
+            logger.exception("Failed to check predicate against %s", walk)
+        else:
+            if included:
+                yield walk.item
+
+
+def patch_and_use_dummy_shim():
+    """
+    Hack ophyd and its dummy shim.  We don't want _any_ control-layer
+    connections being made while we're looking for signals.
+
+    Warning
+    -------
+    Under no circumstances should this be used in a production environment
+    where you intend to actually _use_ ophyd for its intended purpose.
+    """
+    ophyd.Device.lazy_wait_for_connection = False
+
+    def _no_op(*args, **kwargs):
+        ...
+
+    class _PVStandIn:
+        _reference_count = 0
+
+        def __init__(self, pvname, *args, **kwargs):
+            self.pvname = pvname
+            self.connected = True
+
+        add_callback = _no_op
+        remove_callback = _no_op
+        clear_callbacks = _no_op
+        get = _no_op
+        put = _no_op
+        get_with_metadata = _no_op
+        wait_for_connection = _no_op
+
+    def get_pv(pvname, *args, **kwargs):
+        return _PVStandIn(pvname)
+
+    from ophyd import _dummy_shim
+
+    _dummy_shim.get_pv = get_pv
+    _dummy_shim.release_pvs = _no_op
+    ophyd.set_cl("dummy")
+
+
+def find_signals(
+    criteria: CriteriaDict,
+    signal_class: T,
+) -> Generator[T, None, None]:
+    """
+    Find all signal metadata that match the given criteria.
+
+    Yields
+    ------
+    sig : signal_class
+        Signals of type `signal_class`.
+    """
+
+    patch_and_use_dummy_shim()
+
+    def is_of_class(obj):
+        return isinstance(obj, signal_class)
+
+    if not criteria:
+        devices = get_all_devices()
+    else:
+        devices = get_devices_by_criteria(criteria)
+
+    for dev in devices:
+        for sig in get_components_matching(dev, predicate=is_of_class):
+            yield sig
+        # Top-level devices are OK too
+        if isinstance(dev, signal_class):
+            yield dev
+
+
+def find_signal_metadata_pairs(
+    criteria: CriteriaDict,
+) -> Generator[Tuple[str, EpicsSignalBase], None, None]:
+    """
+    Find all signal metadata that match the given criteria.
+    """
+
+    attributes = [
+        "pvname",
+        "setpoint_pvname",
+    ]
+
+    for sig in find_signals(criteria, signal_class=SIGNAL_CLASSES):
+        found_pvs = set()
+        for attr in attributes:
+            pvname = getattr(sig, attr, None)
+            if pvname is not None and isinstance(pvname, str):
+                found_pvs.add(pvname)
+
+        if found_pvs:
+            for pvname in sorted(found_pvs):
+                yield pvname, sig
+        else:
+            # Then it's the prefix - possibly
+            pvname = getattr(sig, "prefix", None)
+            if pvname is not None:
+                yield pvname, sig
+
+
+def _parse_criteria(criteria_string: str) -> CriteriaDict:
+    """
+    Parse search criteria into a dictionary of ``{key: value}``.
+
+    Converts floating point values to float.
+    """
+    search_args = {}
+    for user_arg in criteria_string:
+        if "=" in user_arg:
+            criteria, value = user_arg.split("=", 1)
+        else:
+            criteria = "name"
+            value = user_arg
+
+        if criteria in search_args:
+            logger.warning(
+                "Received duplicate search criteria %s=%r (was %r)",
+                criteria,
+                value,
+                search_args[criteria],
+            )
+            continue
+
+        try:
+            value = float(value)
+        except ValueError:
+            value = fnmatch.translate(value)
+
+        search_args[criteria] = value
+
+    return search_args
+
+
+def _get_argparser(parser: typing.Optional[argparse.ArgumentParser] = None):
+    if parser is None:
+        parser = argparse.ArgumentParser(description=DESCRIPTION)
+
+    parser.add_argument(
+        "search_criteria", nargs="*", help="Search criteria: field=value"
+    )
+    parser.add_argument(
+        "-p", "--pretty", action="store_true", help="Pretty JSON output"
+    )
+    return parser
+
+
+def main(search_criteria: str, pretty: bool = False):
+    client = happi.Client.from_config()
+
+    results = PluginResults(
+        files_to_monitor=[],
+        record_to_metadata=collections.defaultdict(list),
+        metadata=HappiPluginResults(
+            item_to_metadata={
+                item["name"]: item
+                for item in dict(client).values()
+            },
+            record_to_item_name=collections.defaultdict(list),
+            item_to_records=collections.defaultdict(list),
+        )
+    )
+
+    criteria = _parse_criteria(search_criteria)
+    for record, sig in find_signal_metadata_pairs(criteria):
+        if "." in record:
+            record, *_ = record.split(".")
+
+        happi_md = sig.root.md
+        if happi_md.name not in results.metadata.record_to_item_name[record]:
+            results.metadata.record_to_item_name[record].append(happi_md.name)
+            results.record_to_metadata[record].append(happi_md)
+            results.metadata.item_to_records[happi_md.name].append(record)
+
+    return results
+
+
+def _cli_main():
+    parser = _get_argparser()
+    args = parser.parse_args()
+    results = main(**vars(args))
+    json_results = apischema.serialize(results)
+    dump_args = {"indent": 4} if args.pretty else {}
+    print(json.dumps(json_results, sort_keys=True, **dump_args))
+
+
+if __name__ == "__main__":
+    _cli_main()

--- a/whatrecord/plugins/happi.py
+++ b/whatrecord/plugins/happi.py
@@ -77,10 +77,11 @@ def get_all_devices(
     if client is None:
         client = happi.Client.from_config()
 
-    # HACK: TODO: avoid re-re-re-reading the JSON database; happi needs some
-    # work.
-    loaded_database = client.backend._load_or_initialize()
-    client.backend._load_or_initialize = lambda: loaded_database
+    if hasattr(client.backend, "_load_or_initialize"):
+        # HACK: TODO: avoid re-re-re-reading the JSON database; happi needs
+        # some work.
+        loaded_database = client.backend._load_or_initialize()
+        client.backend._load_or_initialize = lambda: loaded_database
 
     for dev in client:
         try:

--- a/whatrecord/plugins/happi.py
+++ b/whatrecord/plugins/happi.py
@@ -77,6 +77,11 @@ def get_all_devices(
     if client is None:
         client = happi.Client.from_config()
 
+    # HACK: TODO: avoid re-re-re-reading the JSON database; happi needs some
+    # work.
+    loaded_database = client.backend._load_or_initialize()
+    client.backend._load_or_initialize = lambda: loaded_database
+
     for dev in client:
         try:
             obj = client[dev].get()

--- a/whatrecord/shell.py
+++ b/whatrecord/shell.py
@@ -275,6 +275,7 @@ class ShellState:
 
     def env_set_EPICS_BASE(self, path):
         # TODO: slac-specific
+        path = str(pathlib.Path(path).resolve())
         version_prefixes = [
             "/reg/g/pcds/epics/base/",
             "/cds/group/pcds/epics/base/",


### PR DESCRIPTION
Closes #26 👏 
Partially addresses #27 

Not finalized, as usual, but I think this isn't a ... terrible form.

I think generally, plugins should be able to - define records, annotate records, annotate IOCs.
As of now, the following is partly supported, allowing happi metadata to find its way to records, and the happi vue to generate a table of its entire set of metadata.

```python
@dataclasses.dataclass
class PluginResults:
    files_to_monitor: List[str]
    metadata: Any
    record_to_metadata: Dict[str, Any]
    # defines records?


@dataclasses.dataclass
class HappiPluginResults:
    item_to_metadata: Dict[str, HappiItem]
    record_to_item_name: Dict[str, List[str]]
    item_to_records: Dict[str, List[str]]
```

## Screenshots

Happi view of database

<img width="1129" alt="image" src="https://user-images.githubusercontent.com/5139267/123719683-072b2100-d837-11eb-9ec3-64c746f8c2a3.png">

Happi view of single item
<img width="1131" alt="image" src="https://user-images.githubusercontent.com/5139267/123719715-18742d80-d837-11eb-8500-b06f36571037.png">

whatrecord indicator linking to happi
<img width="838" alt="image" src="https://user-images.githubusercontent.com/5139267/123719746-29bd3a00-d837-11eb-875f-891cbc9d3693.png">
