### PR TITLE
REF: rework gateway parsing + add frontend view

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,9 +61,9 @@ jobs:
 
     - &testpythonconda
       stage: test
-      name: "Python 3.7 - conda"
+      name: "Python 3.9 - conda"
       env:
-        - PYTHON_VERSION: 3.7
+        - PYTHON_VERSION: 3.9
       install:
         - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
         - bash miniconda.sh -b -p $HOME/miniconda
@@ -96,13 +96,3 @@ jobs:
           set -e
           coverage run --concurrency=thread --parallel-mode -m pytest -vv
           (coverage combine && coverage report | grep -v -e ' 0%') || true
-
-    - <<: *testpythonconda
-      name: "Python 3.8 - conda"
-      env:
-        - PYTHON_VERSION: 3.8
-
-    - <<: *testpythonconda
-      name: "Python 3.9 - conda"
-      env:
-        - PYTHON_VERSION: 3.9

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 recursive-include whatrecord/_whatrecord *.pyx
 recursive-include whatrecord/grammar *.lark
-recursive-include whatrecord/tests *.db *.cmd *.dbd *.proto
+recursive-include whatrecord/tests *.db *.cmd *.dbd *.proto *.pvlist
 include versioneer.py
 include whatrecord/_version.py

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -23,6 +23,9 @@ export default {
         {label: plugin, icon: 'pi pi-fw pi-info-circle', to: '/' + plugin},
       );
       tab_menu_items.push(
+        {label: 'Gateway', icon: 'pi pi-fw pi-shield', to: '/gateway'},
+      );
+      tab_menu_items.push(
         {label: 'Logs', icon: 'pi pi-fw pi-list', to: '/logs'},
       );
     }

--- a/frontend/src/components/gateway-matches.vue
+++ b/frontend/src/components/gateway-matches.vue
@@ -11,21 +11,28 @@
     <tbody>
       <tr v-for="(match, idx) in matches" :key="idx">
         <td>
-          <script-context-link :context="match.context" :short="true" />
+          <script-context-link :context="match.rule.context" :short="true" />
         </td>
         <td>
-          <router-link :to='{ name: "whatrec", params: { record_glob: match.expression }, query: { regex: "true" } }'>
-              {{ match.expression }}
+          <router-link :to='{ name: "whatrec", params: { record_glob: match.rule.pattern }, query: { regex: "true" } }'>
+              {{ match.rule.pattern }}
           </router-link>
         </td>
-        <td>{{ match.details.join(" ") }}</td>
         <td>
-          <!--
-          <template v-if="match.comment_context">
-            <script-context-link :context="match.comment_context" :short="true" />
+          {{ match.rule.command }}
+          <template v-if='match.rule.command == "ALLOW"'>
+            {{ match.rule.access ? match.rule.access : "(DEFAULT)" }}
           </template>
-          -->
-          {{ match.comment }}
+          <template v-else-if='match.rule.command == "DENY"'>
+            Hosts: {{ match.rule.hosts.join(" ") }}
+          </template>
+          <template v-else-if='match.rule.command == "ALIAS"'>
+            {{ match.rule.access ? match.rule.access : "(DEFAULT)" }}
+            {{ match.groups }}
+          </template>
+        </td>
+        <td>
+          <pre>{{ match.rule.header }}</pre>
         </td>
       </tr>
     </tbody>

--- a/frontend/src/components/ioc-info.vue
+++ b/frontend/src/components/ioc-info.vue
@@ -44,6 +44,9 @@ export default {
   computed: {
     file_list () {
       let files = [];
+      if (!this.ioc_info) {
+        return files;
+      }
       for (const [file, hash] of Object.entries(this.ioc_info.loaded_files)) {
         files.push({
           name: file,

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -6,6 +6,7 @@ import IocView from './views/iocs.vue';
 import HappiView from './views/happi.vue';
 import ServerLogView from './views/logs.vue';
 import PVRelationsView from './views/pv_relations.vue';
+import GatewayView from './views/gateway.vue';
 
 import { happi_enabled } from './settings.js';
 
@@ -70,6 +71,14 @@ routes.push(
         name: 'logs',
         path: '/logs',
         component: ServerLogView,
+    },
+)
+
+routes.push(
+    {
+        name: 'gateway',
+        path: '/gateway',
+        component: GatewayView,
     },
 )
 

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -12,6 +12,7 @@ export const store = createStore({
       ioc_to_records: {},
       file_info: {},
       plugin_info: {},
+      gateway_info: null,
       pv_relations: {},
       queries_in_progress: 0,
       query_in_progress: false,
@@ -44,6 +45,9 @@ export const store = createStore({
     set_ioc_info (state, { ioc_info }) {
       state.ioc_info = ioc_info;
     },
+    set_gateway_info (state, { gateway_info }) {
+      state.gateway_info = gateway_info;
+    },
     set_plugin_info (state, { plugin_info }) {
       state.plugin_info = plugin_info;
     },
@@ -67,6 +71,19 @@ export const store = createStore({
         const response = await axios.get(`/api/iocs/*/matches`, {})
         await commit("set_ioc_info", {ioc_info: response.data.matches});
         return response.data.matches;
+      } catch (error) {
+        console.error(error);
+      } finally {
+        await commit("end_query");
+      }
+    },
+
+    async update_gateway_info ({commit}) {
+      try {
+        await commit("start_query");
+        const response = await axios.get(`/api/gateway/info`, {})
+        await commit("set_gateway_info", {gateway_info: response.data});
+        return response.data;
       } catch (error) {
         console.error(error);
       } finally {

--- a/frontend/src/views/gateway.vue
+++ b/frontend/src/views/gateway.vue
@@ -1,0 +1,173 @@
+<template>
+  <div>
+    <DataTable
+      :value="gateway_rows"
+      dataKey="name"
+      filterDisplay="row"
+      v-model:filters="filters"
+      :globalFilterFields="['pattern', 'full_command', 'error', 'file']"
+    >
+      <template #header>
+        <div class="p-d-flex p-jc-between">
+          <Button type="button" icon="pi pi-filter-slash" label="Clear"
+            class="p-button-outlined" @click="clear_filters()"/>
+          <span class="p-input-icon-left">
+            <i class="pi pi-search" />
+            <InputText v-model="filters['global'].value" placeholder="Search" />
+          </span>
+        </div>
+      </template>
+      <Column field="full_command" header="Command">
+        <template #filter="{filterModel,filterCallback}">
+          <InputText type="text" v-model="filterModel.value" @keydown.enter="filterCallback()" class="p-column-filter"
+            :placeholder="`Filter by command`" />
+        </template>
+      </Column>
+      <Column field="pattern" header="Pattern">
+        <template #filter="{filterModel,filterCallback}">
+          <InputText type="text" v-model="filterModel.value" @keydown.enter="filterCallback()" class="p-column-filter"
+            :placeholder="`Filter by pattern`" />
+        </template>
+        <template #body="{data}">
+          <router-link :to='{ name: "whatrec", params: { record_glob: data.pattern }, query: { regex: "true" } }'>
+              {{ data.pattern }}
+          </router-link>
+        </template>
+      </Column>
+      <Column field="comments" header="Comments">
+        <template #filter="{filterModel,filterCallback}">
+          <InputText type="text" v-model="filterModel.value" @keydown.enter="filterCallback()" class="p-column-filter"
+            :placeholder="`Filter by comments`" />
+        </template>
+      </Column>
+      <Column field="error" header="Error">
+        <template #filter="{filterModel,filterCallback}">
+          <InputText type="text" v-model="filterModel.value" @keydown.enter="filterCallback()" class="p-column-filter"
+            :placeholder="`Filter by error`" />
+        </template>
+      </Column>
+      <Column field="short_fn" header="File name">
+        <template #body="{data}">
+          <router-link :to="{ name: 'file', params: { filename: data.filename, line: data.line } }">
+            {{ data.short_fn }}
+          </router-link>
+        </template>
+        <template #filter="{filterModel,filterCallback}">
+          <Dropdown v-model="filterModel.value" :options="filenames"
+            placeholder="Any" class="p-column-filter" :showClear="true"
+            @change="filterCallback()" >
+          </Dropdown>
+        </template>
+      </Column>
+    </DataTable>
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+
+import Button from 'primevue/button';
+import Column from 'primevue/column';
+import DataTable from 'primevue/datatable';
+import Dropdown from 'primevue/dropdown';
+import InputText from 'primevue/inputtext';
+import {FilterMatchMode} from 'primevue/api';
+
+export default {
+  name: 'GatewayView',
+  components: {
+    Button,
+    Column,
+    DataTable,
+    Dropdown,
+    InputText,
+  },
+  props: [],
+  data() {
+    return {
+      filters: null,
+    }
+  },
+  computed: {
+    filenames () {
+      return Object.keys(this.file_to_info).map(
+        fn => fn.replace(/^.*[\\/]/, '')
+      );
+    },
+    gateway_rows () {
+      let table = [];
+      for (const [fn, info] of Object.entries(this.file_to_info)) {
+        const short_fn = fn.replace(/^.*[\\/]/, '');
+        for (const rule of info.rules) {
+          const context = rule.context[0];
+          let details = "";
+          if (rule.command == "ALLOW") {
+            details = rule.access ? rule.access : "(DEFAULT)";
+          } else if (rule.command == "DENY") {
+            details = rule.hosts ? rule.hosts.join(" ") : "(all hosts)";
+          } else if (rule.command == "ALIAS") {
+            const access = rule.access ? rule.access : "(DEFAULT)";
+            details = `->${rule.pvname} ${access}`;
+          }
+          table.push(
+            {
+              short_fn: short_fn,
+              pattern: rule.pattern,
+              full_command: rule.command + " " + details,
+              comments: rule.header,
+              filename: fn,
+              info: info,
+              line: context[1],
+              /*
+              command: rule.command,
+              details: details,
+              */
+              error: "error" in rule.metadata ? "Error: " + rule.metadata["error"] : "",
+            }
+          );
+        }
+      }
+      return table;
+    },
+
+    ...mapState({
+      file_to_info (state) {
+        return state.gateway_info || {};
+      },
+
+    }),
+  },
+  created() {
+    this.init_filters();
+  },
+  mounted() {
+    if (Object.keys(this.file_to_info).length == 0) {
+      this.$store.dispatch("update_gateway_info");
+    }
+  },
+
+  async beforeRouteUpdate(to, from) {  // eslint-disable-line
+    /* this.from_params(to.params); */
+  },
+
+  methods: {
+    clear_filters() {
+      this.init_filters();
+    },
+
+    init_filters() {
+      this.filters = {
+        global: {value: this.filter, matchMode: FilterMatchMode.CONTAINS},
+        full_command: {value: null, matchMode: FilterMatchMode.CONTAINS},
+        pattern: {value: null, matchMode: FilterMatchMode.CONTAINS},
+        error: {value: null, matchMode: FilterMatchMode.CONTAINS},
+        comments: {value: null, matchMode: FilterMatchMode.CONTAINS},
+        short_fn: {value: null, matchMode: FilterMatchMode.CONTAINS},
+      };
+    }
+  }
+}
+</script>
+
+<style scoped>
+</style>

--- a/frontend/src/views/whatrec.vue
+++ b/frontend/src/views/whatrec.vue
@@ -34,7 +34,8 @@ export default {
       return this.$route.params.record_glob || "";
     },
     selected_records () {
-      return this.$route.params.selected_records.split("|") || [];
+      const records = this.$route.params.selected_records;
+      return (records || "").split("|");
     },
     ...mapState({
       record_info (state) {

--- a/whatrecord/common.py
+++ b/whatrecord/common.py
@@ -10,6 +10,7 @@ from time import perf_counter
 from typing import Any, ClassVar, Dict, Generator, List, Optional, Tuple, Union
 
 import apischema
+import lark
 
 from _whatrecord.common import IocshRedirect
 
@@ -780,3 +781,8 @@ def time_context():
         return perf_counter() - start_count
 
     yield inner
+
+
+def context_from_lark_token(fn: str, token: lark.Token) -> FullLoadContext:
+    """Get a full load context from a given lark Token."""
+    return (LoadContext(name=fn, line=token.line), )

--- a/whatrecord/grammar/gateway.lark
+++ b/whatrecord/grammar/gateway.lark
@@ -1,0 +1,49 @@
+// Handwritten EPICS gateway pvlist configuration grammar
+
+?start: pvlist
+
+pvlist: evaluation? _pvlist_item*
+
+!evaluation: "evaluation"i "order"i evaluation_order NEWLINE
+_pvlist_item: _rule
+
+!evaluation_order: "deny"i "," "allow"i
+                 | "allow"i "," "deny"i
+
+pattern: /\S+/
+
+_rule: deny
+     | alias
+     | allow
+
+TOK_ALLOW: "ALLOW"i
+TOK_ALIAS: "ALIAS"i
+TOK_DENY: "DENY"i
+
+deny: pattern TOK_DENY ("FROM"i hosts)? NEWLINE
+alias: pattern TOK_ALIAS pvname asg_asl? NEWLINE
+allow: pattern TOK_ALLOW asg_asl? NEWLINE
+
+asg_asl: asg asl?
+hosts: host+
+
+host: /\S+/
+pvname: /\S+/
+asg: /\S+/
+
+ASL0: "0"
+ASL1: "1"
+
+asl: ASL0
+   | ASL1
+
+%import common.WS_INLINE
+%import common.WS
+%import common.CR
+%import common.LF
+%import common.NEWLINE
+%ignore WS_INLINE
+%ignore WS
+
+COMMENT     : "#" /[^\n\r]/*
+%ignore COMMENT

--- a/whatrecord/shell.py
+++ b/whatrecord/shell.py
@@ -228,9 +228,14 @@ class ShellState:
         finally:
             self.load_context.remove(load_ctx)
 
-    def get_asyn_port_from_record(self, inst: RecordInstance):
+    def get_asyn_port_from_record(self, inst: RecordInstance) -> Optional[asyn.AsynPort]:
+        """Given a record, return its related asyn port."""
         rec_field = inst.fields.get("INP", inst.fields.get("OUT", None))
         if rec_field is None:
+            return
+
+        if not isinstance(rec_field.value, str):
+            # No PVAccess links just yet
             return
 
         value = rec_field.value.strip()

--- a/whatrecord/tests/kfe.pvlist
+++ b/whatrecord/tests/kfe.pvlist
@@ -1,0 +1,136 @@
+EVALUATION ORDER ALLOW, DENY
+
+###########################################################
+# LCLS-II Naming convention patterns
+
+# Allow K beamline devices w/ naming conventions
+# starting w/ 2 char device code and device number,
+# followed by K0, K1, K2, ...
+[A-Z][A-Z][0-9]K[01234]:.* ALLOW
+[A-Z][A-Z][A-Z]:KFE:.*     ALLOW
+
+# Some RIX devices temporarily on KFE subnet
+[A-Z][A-Z][A-Z]:RIX:.*     ALLOW
+
+# Deny KFE camera images
+[A-Z][A-Z][0-9]K[01234]:.*:ArrayData   DENY
+[A-Z][A-Z][A-Z]:KFE:.*:ArrayData       DENY
+
+# Allow devices w/ stand naming convention
+# starting w/ line code K0, K1, K2, ...
+# followed by stand number, S0, S3, S3A, S10, ...
+K[01234]S[0-9]+:.*         ALLOW
+
+# Special case names
+RTDSK0:.*                  ALLOW
+PCPM3B:.*                  ALLOW
+PMPS.*                     ALLOW
+
+# Special case - ioc-archstats runs here
+ARCH:.*                    ALLOW
+
+# Special case - vacuum system overrides, etc
+PLC:KFE:VAC:.*		ALLOW RWINSTRMCC 1
+RIX:FEE:VAC:.*		ALLOW RWINSTRMCC 1
+RIX:HUT:VAC:.*		ALLOW RWINSTRMCC 1
+
+# PMPS FFO/Arbiter Permissions
+PLC:KFE:.*		ALLOW RWINSTRMCC 1
+PLC:RIX:.*		ALLOW RWINSTRMCC 1
+
+# Allow read only access to KFE:.*
+KFE:.*	        ALLOW
+# Allow R/W access for INSTR to KFE:.*
+KFE:.*	        ALLOW RWINSTR 1
+
+PCPM3B:.*		ALLOW RWINSTRMCC 1
+
+AT1K0:.*		ALLOW RWINSTRMCC 1
+EM1K0:.*		ALLOW RWINSTRMCC 1
+EM2K0:.*		ALLOW RWINSTRMCC 1
+IM1K0:.*		ALLOW RWINSTRMCC 1
+IM2K0:.*		ALLOW RWINSTRMCC 1
+PA1K0:.*		ALLOW RWINSTRMCC 1
+PC1K0:.*		ALLOW RWINSTRMCC 1
+PF1K0:.*		ALLOW RWINSTRMCC 1
+RTDSK0:.*		ALLOW RWINSTRMCC 1
+SL1K0:.*		ALLOW RWINSTRMCC 1
+SL2K0:.*		ALLOW RWINSTRMCC 1
+ST1K1:.*		ALLOW RWINSTRMCC 1
+TV2K0:.*		ALLOW RWINSTRMCC 1
+TV3K0:.*		ALLOW RWINSTRMCC 1
+
+IM1K1:.*		ALLOW RWINSTRMCC 1
+IM2K1:.*		ALLOW RWINSTRMCC 1
+MR1K1:.*		ALLOW RWINSTRMCC 1
+MR2K1:.*		ALLOW RWINSTRMCC 1
+PC1K1:.*		ALLOW RWINSTRMCC 1
+SP1K1:.*		ALLOW RWINSTRMCC 1
+TV1K1:.*		ALLOW RWINSTRMCC 1
+
+AL1K2:.*		ALLOW RWINSTRMCC 1
+IM1K2:.*		ALLOW RWINSTRMCC 1
+IM2K2:.*		ALLOW RWINSTRMCC 1
+IM3K2:.*		ALLOW RWINSTRMCC 1
+IM4K2:.*		ALLOW RWINSTRMCC 1
+IM5K2:.*		ALLOW RWINSTRMCC 1
+LI2K2:.*		ALLOW RWINSTRMCC 1
+PF1K2:.*		ALLOW RWINSTRMCC 1
+MR1K2:.*		ALLOW RWINSTRMCC 1
+SL1K2:.*		ALLOW RWINSTRMCC 1
+ST1K2:.*		ALLOW RWINSTRMCC 1
+TV1K2:.*		ALLOW RWINSTRMCC 1
+TM1K2:.*		ALLOW RWINSTRMCC 1
+TM2K2:.*		ALLOW RWINSTRMCC 1
+
+MR1K3:.*		ALLOW RWINSTRMCC 1
+MR2K3:.*		ALLOW RWINSTRMCC 1
+
+AT1K4:.*		ALLOW RWINSTRMCC 1
+AL1K4:.*		ALLOW RWINSTRMCC 1
+IM1K4:.*		ALLOW RWINSTRMCC 1
+IM2K4:.*		ALLOW RWINSTRMCC 1
+MR1K4:.*		ALLOW RWINSTRMCC 1
+MR2K4:.*		ALLOW RWINSTRMCC 1
+MR3K4:.*		ALLOW RWINSTRMCC 1
+ST1K4:.*		ALLOW RWINSTRMCC 1
+
+.*FFO.*		ALLOW RWINSTRMCC 1
+
+# Deny RIX PVs w/ same naming convention as kfe
+SL1K2:EXIT:CAM:.*   DENY
+
+# Allow write access to PMPS Configuration Params from SX control rooms:
+PMPS:KFE:BeamParamCntl.*	ALLOW RWSXR 1
+
+# Allow write access to XGMD HV control from soft xray control rooms and ACR
+EM2K0:XGMD:SHV:.*          ALLOW RWSXRMCC
+
+###########################################################
+# LCLS-I Naming convention patterns
+# Are we ready to drop these since SXR hutch is no more?
+
+SXR.*	ALLOW
+.*LJE.*	ALLOW
+HX2:SB1:IPM.* ALLOW
+SXR:YAG:EVR:01.* ALLOW RWINSTRMCC 1
+SXR:YAG:IOC:01.* ALLOW RWINSTRMCC 1
+SXR:YAG:CVV:01.* ALLOW RWINSTRMCC 1
+HX2:SB1:IPM.* ALLOW RWINSTRMCC 1
+
+# GMD pv's handled by sxr-gmd gateway
+SXR:GMD:BLD:.*		DENY
+
+# camera images handled by sxr-cam gateway
+SXR:.*IMAGE.*		DENY
+SXR:.*Image.*		DENY
+SXR:.*PROJ.*		DENY
+SXR:.*HPrj.*		DENY
+
+# Keep this as the last pattern please
+
+# Keep this as the last pattern please
+# Add write permission for gateway diagnostic pvs
+# To reread config file:
+#	caput NET:CAG:KFE:newAsFlag 1
+NET:CAG:KFE.*      ALLOW RWALL 1

--- a/whatrecord/tests/test_gateway.py
+++ b/whatrecord/tests/test_gateway.py
@@ -1,0 +1,223 @@
+import pytest
+
+from .. import util
+from ..common import LoadContext
+from ..gateway import (AccessSecurity, AliasRule, AllowRule, DenyRule,
+                       GatewayConfig, PVList, PVListMatch, PVListMatches)
+from .conftest import MODULE_PATH
+
+
+@pytest.fixture
+def kfe_pvlist():
+    return PVList.from_file(
+        (MODULE_PATH / "kfe.pvlist").resolve()
+    )
+
+
+@pytest.fixture
+def gateway_config():
+    return GatewayConfig(path=MODULE_PATH, glob_str="*.pvlist")
+
+
+@pytest.mark.parametrize(
+    "rule, expected",
+    [
+        pytest.param(
+            "SXR:YAG:CVV:01.* ALLOW RWINSTRMCC 1",
+            AllowRule(
+                context=(LoadContext("None", 1), ),
+                command="ALLOW",
+                pattern="SXR:YAG:CVV:01.*",
+                access=AccessSecurity(
+                    group="RWINSTRMCC",
+                    level="1",
+                )
+            ),
+            id="allow_basic",
+        ),
+        pytest.param(
+            "SXR:YAG:CVV:01.* DENY",
+            DenyRule(
+                context=(LoadContext("None", 1), ),
+                command="DENY",
+                pattern="SXR:YAG:CVV:01.*",
+                hosts=None,
+            ),
+            id="deny_basic",
+        ),
+        pytest.param(
+            "SXR:YAG:CVV:01.* DENY FROM host1",
+            DenyRule(
+                context=(LoadContext("None", 1), ),
+                command="DENY",
+                pattern="SXR:YAG:CVV:01.*",
+                hosts=["host1"],
+            ),
+            id="deny_host",
+        ),
+        pytest.param(
+            "SXR:YAG:CVV:01.* DENY FROM host1 host2",
+            DenyRule(
+                context=(LoadContext("None", 1), ),
+                command="DENY",
+                pattern="SXR:YAG:CVV:01.*",
+                hosts=["host1", "host2"],
+            ),
+            id="deny_hosts",
+        ),
+        pytest.param(
+            r":gateway\.\(.*\)Flag        ALIAS     gateway:\1Flag       ",
+            AliasRule(
+                context=(LoadContext("None", 1), ),
+                command="ALIAS",
+                pattern=r":gateway\.\(.*\)Flag",
+                pvname=r"gateway:\1Flag",
+                access=None,
+            ),
+            id="alias",
+        ),
+        pytest.param(
+            r":gateway\.\(.*\)Flag        ALIAS     gateway:\1Flag          GatewayAdmin",
+            AliasRule(
+                context=(LoadContext("None", 1), ),
+                command="ALIAS",
+                pattern=r":gateway\.\(.*\)Flag",
+                pvname=r"gateway:\1Flag",
+                access=AccessSecurity(
+                    group="GatewayAdmin",
+                    level=None,
+                )
+            ),
+            id="alias_access",
+        ),
+
+        pytest.param(
+            "*        ALIAS     gateway:Flag",
+            AliasRule(
+                context=(LoadContext("None", 1), ),
+                command="ALIAS",
+                pattern="*",
+                pvname="gateway:Flag",
+                # Hard to test for, as this is set automatically:
+                # metadata={
+                #     "error": (
+                #         "Invalid regex. error: nothing to "
+                #         "repeat at position 0'",
+                #     )
+                # }
+            ),
+            id="invalid_pattern",
+        ),
+
+    ]
+)
+def test_rule(rule, expected):
+    assert PVList.from_string(rule).rules[0] == expected
+
+
+def test_eval_order():
+    assert PVList.from_string(
+        "evaluation order allow, deny"
+    ).evaluation_order == "ALLOW, DENY"
+
+
+def test_full():
+    source = """
+        # Header Text 1
+        # Header Text 2
+        evaluation order allow, deny
+
+        # Skipped Comment
+
+        # Rule Comment 1
+        # Rule Comment 2
+        SXR:YAG:CVV:01.* ALLOW RWINSTRMCC 1
+    """
+
+    source_hash = util.get_bytes_sha256(source.encode("utf-8"))
+    assert PVList.from_string(
+        source,
+        filename="filename",
+    ) == PVList(
+        filename="filename",
+        evaluation_order="ALLOW, DENY",
+        comments=[
+            "Header Text 1",
+            "Header Text 2",
+            "Skipped Comment",
+            "Rule Comment 1",
+            "Rule Comment 2",
+        ],
+        header="Header Text 1\nHeader Text 2",
+        hash=source_hash,
+        rules=[
+            AllowRule(
+                context=(LoadContext("filename", 9), ),
+                command="ALLOW",
+                pattern="SXR:YAG:CVV:01.*",
+                access=AccessSecurity(
+                    group="RWINSTRMCC",
+                    level="1",
+                ),
+                header="Rule Comment 1\nRule Comment 2",
+            ),
+        ],
+    )
+
+
+def test_match_without_context(kfe_pvlist: PVList):
+    assert list(kfe_pvlist.match("IOC:KFE:ABC")) == [
+        (
+            AllowRule(
+                context=(LoadContext(kfe_pvlist.filename, 10,), ),
+                pattern="[A-Z][A-Z][A-Z]:KFE:.*",
+                command="ALLOW",
+                # regex=re.compile("[A-Z][A-Z][A-Z]:KFE:.*"),
+                header="",
+                metadata={},
+                access=None,
+            ),
+            []
+        )
+    ]
+
+
+def test_match_with_context(kfe_pvlist: PVList):
+    assert list(kfe_pvlist.match("IOC:RIX:ABC")) == [
+        (
+            AllowRule(
+                context=(LoadContext(kfe_pvlist.filename, 13,), ),
+                pattern="[A-Z][A-Z][A-Z]:RIX:.*",
+                command="ALLOW",
+                # regex=re.compile("[A-Z][A-Z][A-Z]:KFE:.*"),
+                header="Some RIX devices temporarily on KFE subnet",
+                metadata={},
+                access=None,
+            ),
+            []
+        )
+    ]
+
+
+def test_gateway_config(kfe_pvlist: PVList, gateway_config: GatewayConfig):
+    gateway_config.update_changed()
+
+    kfe_fn = str(kfe_pvlist.filename)
+    assert gateway_config.get_matches("IOC:RIX:ABC") == PVListMatches(
+        name="IOC:RIX:ABC",
+        matches=[
+            PVListMatch(
+                filename=kfe_fn,
+                rule=AllowRule(
+                    context=(LoadContext(kfe_fn, 13,), ),
+                    pattern="[A-Z][A-Z][A-Z]:RIX:.*",
+                    command="ALLOW",
+                    # regex=re.compile("[A-Z][A-Z][A-Z]:KFE:.*"),
+                    header="Some RIX devices temporarily on KFE subnet",
+                    metadata={},
+                    access=None,
+                ),
+                groups=[],
+            ),
+        ]
+    )

--- a/whatrecord/tests/test_server_state.py
+++ b/whatrecord/tests/test_server_state.py
@@ -4,7 +4,7 @@ import logging
 import pytest
 
 from ..server.server import ServerState, _new_server_state
-from .conftest import STARTUP_SCRIPTS
+from .conftest import MODULE_PATH, STARTUP_SCRIPTS
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +17,7 @@ def test_init_basic():
 def state():
     return _new_server_state(
         scripts=[str(script) for script in STARTUP_SCRIPTS],
+        gateway_config=str(MODULE_PATH),
     )
 
 
@@ -27,6 +28,7 @@ def ready_state(state: ServerState, caplog):
     logger.info("Updating script loaders")
     asyncio.run(state.update_script_loaders())
     asyncio.run(state.update_iocs(state.get_updated_iocs()))
+    state._load_gateway_config()
     # asyncio.run(state.update_plugins())
     return state
 


### PR DESCRIPTION
The gateway view and restructuring, finished up from yesterday. (More lark grammars 👏 )

Much easier to browse and search gateway rules now.

Closes #60 

<img width="1113" alt="image" src="https://user-images.githubusercontent.com/5139267/127075780-4a28add9-de3f-46c8-8a3a-c83cdc4ade4e.png">

And stuff that was part of the old linter functionality:

<img width="1088" alt="image" src="https://user-images.githubusercontent.com/5139267/127075815-17fa736d-5b3e-48ed-a758-d2a351ba8fae.png">
