### PR TITLE
ENH: show asg in frontend; add dbLoadTemplate support to IOC shell interpreter

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "es6-promise": "^4.2.8",
     "primeflex": "^2.0.0",
     "primeicons": "^4.1.0",
-    "primevue": "^3.5.0",
+    "primevue": "3.6.0",
     "vue": "^3.0.0",
     "vue-router": "^4.0.8",
     "vuex": "^4.0.1"

--- a/frontend/src/components/dictionary-table.vue
+++ b/frontend/src/components/dictionary-table.vue
@@ -79,6 +79,9 @@ export default {
     },
     filtered_dict() {
       let filtered = {};
+      if (this.dict === null || this.dict === undefined) {
+          return filtered;
+      }
       for (const [key, value] of Object.entries(this.dict)) {
         if (this.skip_keys.indexOf(key) < 0 && value != null) {
           const looks_worth_displaying = (

--- a/frontend/src/components/epics-format-record.vue
+++ b/frontend/src/components/epics-format-record.vue
@@ -70,7 +70,7 @@ export default {
   },
   computed: {
     info_nodes() {
-      const skip_keys = ["gateway", "archived", "happi", "streamdevice"];
+      const skip_keys = ["asg", "gateway", "archived", "happi", "streamdevice"];
       return Object.entries(this.metadata).filter(
         item => skip_keys.indexOf(item[0]) < 0
       );

--- a/frontend/src/components/epics-format-record.vue
+++ b/frontend/src/components/epics-format-record.vue
@@ -10,7 +10,7 @@
       <!-- fields -->
       <template v-for="field in fields" :key="field.name">
         <epics-format-field :field="field"
-            :field_info="record_defn.fields[field.name]"
+            :field_info="record_defn ? record_defn.fields[field.name] : null"
             :menus="menus"
             />
       </template>

--- a/frontend/src/components/recordinfo.vue
+++ b/frontend/src/components/recordinfo.vue
@@ -85,7 +85,7 @@
         <img class="svg-graph" :src="graph_link" />
       </a>
     </AccordionTab>
-    <AccordionTab header="Archiver" :disabled="record == null">
+    <AccordionTab header="Archiver" v-if="record != null">
       <template v-if="record != null && appliance_viewer_url">
         <a :href="appliance_viewer_url" target="_blank">
           Archive Viewer
@@ -96,7 +96,7 @@
           />
         </template>
     </AccordionTab>
-    <AccordionTab header="Gateway" :disabled="record == null">
+    <AccordionTab header="Gateway" v-if="record != null">
       <template v-if="record != null && record.metadata.gateway != null && record.metadata.gateway.matches.length > 0">
         Matching gateway rules:
         <gateway-matches :matches="record.metadata.gateway.matches"/>
@@ -105,7 +105,14 @@
         No matches with gateway rules.
       </template>
     </AccordionTab>
-    <AccordionTab header="Asyn" :disabled="whatrec.asyn_ports.length == 0">
+    <AccordionTab header="Access Security Group" v-if="asg != null">
+      <dictionary-table
+        :dict="asg"
+        :cls="'metadata'"
+        :skip_keys="[]"
+      />
+    </AccordionTab>
+    <AccordionTab header="Asyn" v-if="whatrec.asyn_ports.length > 0">
       <asyn-port
         v-for:="(asyn_port, idx) in whatrec.asyn_ports"
         :asyn_port="asyn_port"
@@ -189,6 +196,12 @@ export default {
     },
     record_defn() {
       return this.whatrec.record ? this.whatrec.record.definition : null;
+    },
+    asg() {
+      if (this.record == null) {
+        return null;
+      }
+      return this.record.metadata["asg"];
     },
     streamdevice_metadata() {
       if (this.record == null) {

--- a/frontend/src/components/searchbar.vue
+++ b/frontend/src/components/searchbar.vue
@@ -103,7 +103,12 @@ export default {
         }
       }
 
-      document.title = `WhatRecord? ${pattern} (${selected_records})`;
+      if (selected_records.length > 0) {
+          document.title = `WhatRecord? ${selected_records}`;
+      } else {
+          document.title = "WhatRecord?";
+      }
+
       await this.$store.dispatch(
         "find_record_matches",
         {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6740,10 +6740,10 @@ primeicons@^4.1.0:
   resolved "https://registry.npmjs.org/primeicons/-/primeicons-4.1.0.tgz"
   integrity sha512-uEv2pSPk1zQCfaB2VgnUfnUxxlGryYi+5rbdxmZBBt5v9S/pscIQYS5YDLxsQZ7D9jn5c76+Tx5wX/2J1nK6sA==
 
-primevue@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.npmjs.org/primevue/-/primevue-3.5.0.tgz"
-  integrity sha512-IB8CJ8JZF2X18F5NG13fMKwG/zUJ215pbWXdoNxMSULvybqnVRlS4xDCy1zm9DWnGgozjANNuptcCpNj5D3Hbw==
+primevue@3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/primevue/-/primevue-3.6.0.tgz#7317386b1f158b0ee447809635785d04443906a9"
+  integrity sha512-f1CqdNYLUnh8/iZp7xEFmcDbxUcbcg6yffXMYkyFhnKC+s1usgbTGuw4xyMMUO9dl5hSdTOeKzWnrB97toBFuA==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"

--- a/whatrecord/common.py
+++ b/whatrecord/common.py
@@ -649,6 +649,13 @@ record("{{record_type}}", "{{name}}") {
 """,
     }
 
+    @property
+    def access_security_group(self) -> str:
+        """The access security group name for the record."""
+        if "ASG" in self.fields and not self.is_pva:
+            return str(self.fields["ASG"].value)
+        return "DEFAULT"
+
     def get_fields_of_type(self, *types) -> Generator[RecordField, None, None]:
         """Get all fields of the matching type(s)."""
         for fld in self.fields.values():

--- a/whatrecord/common.py
+++ b/whatrecord/common.py
@@ -658,6 +658,9 @@ record("{{record_type}}", "{{name}}") {
 
     def get_fields_of_type(self, *types) -> Generator[RecordField, None, None]:
         """Get all fields of the matching type(s)."""
+        if self.is_pva:
+            return
+
         for fld in self.fields.values():
             if fld.dtype in types:
                 yield fld

--- a/whatrecord/shell.py
+++ b/whatrecord/shell.py
@@ -63,14 +63,28 @@ class ShellState:
         Rewrite hard-coded directory prefixes by setting::
 
             standin_directories = {"/replace_this/": "/with/this"}
+    access_security : AccessSecurityConfig
+        The loaded access security configuration (post iocInit).
+    access_security_filename : pathlib.Path
+        The access security filename.
+    access_security_macros : Dict[str, str]
+        Macros used when expanding the access security file.
+    asyn_ports : Dict[str, asyn.AsynPortBase]
+        Asyn ports defined by name.
+    loaded_files : Dict[str, str]
+        Files loaded, mapped to a hash of their contents.
     working_directory : pathlib.Path
         Current working directory.
     database_definition : Database
         Loaded database definition (dbd).
     database : Dict[str, RecordInstance]
         The IOC database of records.
+    pva_database : Dict[str, RecordInstance]
+        The IOC database of PVAccess groups.
     aliases : Dict[str, str]
         Alias name to record name.
+    streamdevice : Dict[str, StreamProtocol]
+        Loadd StreamDevice protocols by name.
     load_context : List[MutableLoadContext]
         Current loading context stack (e.g., ``st.cmd`` then
         ``common_startup.cmd``).  Modified in place as scripts are evaluated.

--- a/whatrecord/shell.py
+++ b/whatrecord/shell.py
@@ -932,7 +932,7 @@ class LoadedIoc:
     ) -> Optional[WhatRecord]:
         """Get record information, optionally including PVAccess results."""
         state = self.shell_state
-        v3_inst = state.database.get(rec, None)
+        v3_inst = state.database.get(state.aliases.get(rec, rec), None)
         pva_inst = state.pva_database.get(rec, None) if include_pva else None
         if not v3_inst and not pva_inst:
             return

--- a/whatrecord/tests/iocs/ioc_dbloadtemplate/st.cmd
+++ b/whatrecord/tests/iocs/ioc_dbloadtemplate/st.cmd
@@ -1,0 +1,16 @@
+#!/usr/bin/env softIoc
+
+epicsEnvSet( "ENGINEER", "Engineer" )
+epicsEnvSet( "LOCATION", "Location" )
+epicsEnvSet( "IOCSH_PS1", "ioc-dbloadtemplate> " )
+epicsEnvSet( "EPICS_BASE", "/cds/group/pcds/epics/base/R7.0.2" )
+
+dbLoadDatabase("../softIoc.dbd", 0, 0)
+
+softIoc_registerRecordDeviceDriver(pdbbase)
+
+dbLoadTemplate "../db/test.substitutions"
+
+iocInit
+
+dbl

--- a/whatrecord/tests/test_bin_parse.py
+++ b/whatrecord/tests/test_bin_parse.py
@@ -47,7 +47,8 @@ def test_load_and_whatrec(startup_script):
         dbd = whatrec.record.definition
         assert whatrec.name == rec.name == pvname
         assert rec == state.database[pvname]
-        assert dbd == state.database_definition.record_types[rec.record_type]
+        if rec.record_type != "motor":  # sorry, dbd doesn't have it
+            assert dbd == state.database_definition.record_types[rec.record_type]
 
     pva_db = state.pva_database
     if pva_db:


### PR DESCRIPTION
Closes #70 

Load context is pretty great now:
### Top-level
<img width="733" alt="image" src="https://user-images.githubusercontent.com/5139267/128275212-7bbe09c4-f711-4274-ac8a-fced16d06b55.png">

### Drilling down from startup script
<img width="904" alt="image" src="https://user-images.githubusercontent.com/5139267/128275338-fbcf19c3-3f33-475b-86e6-1fba2c428942.png">

### To substitutions
<img width="1260" alt="image" src="https://user-images.githubusercontent.com/5139267/128275347-bcd259ee-8925-4055-8b0d-865155a3bc2a.png">

### To database
<img width="868" alt="image" src="https://user-images.githubusercontent.com/5139267/128275372-0ed3101e-3f30-4954-9f8c-b7147b936747.png">

### Issue

Only remaining issue is that the frontend display of output is pretty terrible for st.cmd:
<img width="1144" alt="image" src="https://user-images.githubusercontent.com/5139267/128275469-fc7fb6c3-bf48-4360-94c9-4c8173a7575b.png">
