### PR TITLE
BUG: use fullmatch to evaluate gateway rules to reflect gateway behavior

### DIFF
--- a/whatrecord/gateway.py
+++ b/whatrecord/gateway.py
@@ -43,7 +43,7 @@ class Rule:
     def match(self, name):
         """Match a pv name against this rule."""
         if self.regex is not None:
-            return self.regex.match(name)
+            return self.regex.fullmatch(name)
 
 
 @dataclass


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
When evaluating a gateway access regex, use `fullmatch` instead of `match` to reflect the behavior of the epics gateway.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`match` will match substrings starting from the beginning of the string.
`fullmatch` will only match if the full string matches.
closes #91 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`predict_gateway_response` from `pcds-gateway-tests` for `'LAS:FS1:Angle:Shift:Ramp:Target_1MIN_AVG'` behaves as expected with this patch

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
N/A

<!--
## Screenshots (if appropriate):
-->
