### PR TITLE
ENH: EPICS sequencer state notation language (snl) grammar+parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,8 @@ jobs:
   include:
     - &testpythonpip
       stage: test
-      name: "Python 3.8 - PIP"
-      python: 3.8
+      name: "Python 3.9 - PIP"
+      python: 3.9
       install:
         - python -m pip install --upgrade pip
         - python -m pip install .
@@ -51,10 +51,6 @@ jobs:
           set -e
           coverage run --concurrency=thread --parallel-mode -m pytest -vv
           (coverage combine && coverage report | grep -v -e ' 0%') || true
-
-    - <<: *testpythonpip
-      name: "Python 3.9 - PIP"
-      python: 3.9
 
     - &testpythonconda
       stage: test

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 recursive-include whatrecord/_whatrecord *.pyx
 recursive-include whatrecord/grammar *.lark
-recursive-include whatrecord/tests *.db *.cmd *.dbd *.proto *.pvlist *.acf t1-*.txt *.st
+recursive-include whatrecord/tests *.db *.cmd *.dbd *.proto *.pvlist *.acf t1-*.txt *.st LICENSE
 recursive-include whatrecord/tests *.substitutions *.substitutions.expanded
 include versioneer.py
 include whatrecord/_version.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 recursive-include whatrecord/_whatrecord *.pyx
 recursive-include whatrecord/grammar *.lark
-recursive-include whatrecord/tests *.db *.cmd *.dbd *.proto *.pvlist *.acf t1-*.txt
+recursive-include whatrecord/tests *.db *.cmd *.dbd *.proto *.pvlist *.acf t1-*.txt *.st
 recursive-include whatrecord/tests *.substitutions *.substitutions.expanded
 include versioneer.py
 include whatrecord/_version.py

--- a/whatrecord/bin/parse.py
+++ b/whatrecord/bin/parse.py
@@ -21,6 +21,7 @@ from ..format import FormatContext
 from ..gateway import PVList as GatewayPVList
 from ..macro import MacroContext
 from ..shell import LoadedIoc
+from ..snl import SequencerProgram
 from ..streamdevice import StreamProtocol
 
 logger = logging.getLogger(__name__)
@@ -103,6 +104,7 @@ ParseResult = Union[
     GatewayPVList,
     LinterResults,
     LoadedIoc,
+    SequencerProgram,
     StreamProtocol,
     TemplateSubstitution,
 ]
@@ -190,6 +192,9 @@ def parse(
             dbd=Database.from_file(dbd) if dbd is not None else None,
             filename=filename,
         )
+
+    if format == FileFormat.state_notation:
+        return SequencerProgram.from_file(filename)
 
     with open(filename, "rt") as fp:
         contents = fp.read()

--- a/whatrecord/common.py
+++ b/whatrecord/common.py
@@ -35,6 +35,7 @@ class FileFormat(str, enum.Enum):
     gateway_pvlist = 'gateway_pvlist'
     access_security = 'access_security'
     stream_protocol = 'stream_protocol'
+    state_notation = 'state_notation'
 
     @classmethod
     def from_extension(cls, extension: str) -> FileFormat:
@@ -48,6 +49,7 @@ class FileFormat(str, enum.Enum):
             "pvlist": FileFormat.gateway_pvlist,
             "acf": FileFormat.access_security,
             "proto": FileFormat.stream_protocol,
+            "st": FileFormat.state_notation,
         }[extension.lower()]
 
     @classmethod

--- a/whatrecord/grammar/snl.lark
+++ b/whatrecord/grammar/snl.lark
@@ -1,6 +1,9 @@
 // Attempt at a state notation language (snl/seq) grammar
 //
 // snl itself uses re2c and an LALR-based lemon grammar.
+//
+// Limitations:
+//  * Preprocessor support (#include is OK, #ifdef and such get ignored)
 
 ?start: program
 
@@ -10,11 +13,13 @@
 WHITESPACE: /[ \t\v\f]+/
 %ignore WHITESPACE
 
-MULTI_LINE_COMMENT: /\/\*.*?\*\//s
+MULTI_LINE_COMMENT: "/*" /./s* "*/"
 SINGLE_LINE_COMMENT: "//" /[^\n]/*
 
-%ignore MULTI_LINE_COMMENT
-%ignore SINGLE_LINE_COMMENT
+COMMENT: MULTI_LINE_COMMENT
+       | SINGLE_LINE_COMMENT
+
+%ignore COMMENT
 
 NL: /[\n]/
 ANY: /[^]/
@@ -41,7 +46,7 @@ MONITOR: "monitor"
 OPTION: "option"
 PROGRAM: "program"
 RETURN: "return"
-SS: "ss"
+STATE_SET: "ss"
 STATE: "state"
 STRING: "string"
 SYNCQ: "syncQ"
@@ -74,8 +79,8 @@ UINT16T: "uint16_t"
 INT32T: "int32_t"
 UINT32T: "uint32_t"
 
-TYPEWORD: CHAR | CONST | DOUBLE | ENUM | EVFLAG | FLOAT | FOREIGN | INT 
-        | INT16T | INT32T | INT8T | LONG | SHORT | SIZEOF | STRUCT 
+TYPEWORD: CHAR | CONST | DOUBLE | ENUM | EVFLAG | FLOAT | FOREIGN | INT
+        | INT16T | INT32T | INT8T | LONG | SHORT | SIZEOF | STRUCT
         | TYPENAME | UINT16T | UINT32T | UINT8T | UNION | UNSIGNED | VOID
 
 // "seqg_" (LET|DEC)*  -> "identifier '%s'starts with reserved prefix\n"
@@ -160,8 +165,8 @@ STRCON: "\"" (ESC | /[^"\n\\]/)* "\""
 LINE_MARKER: DEC+ SPC*
            | "\"" (ESC | /[^\n\\"]/)* "\""
 
-CCODE: "%{" /./* "}%"
-     | "%%" /[^\n]/*
+CCODE: "%{" /./s* "}%"
+     | "%%" /[^\n]*/
 
 // The program itself
 
@@ -197,7 +202,7 @@ to: TO?
 
 strings: strings COMMA string
        | string
-       | 
+       |
 
 monitor: MONITOR variable opt_subscript SEMICOLON
 // | MONITOR variable opt_subscript error SEMICOLON
@@ -235,7 +240,7 @@ declarator: variable
           | ASTERISK declarator
           | CONST declarator
 
-param_decls: 
+param_decls:
            | param_decl
            | param_decls COMMA param_decl
 
@@ -254,12 +259,12 @@ init_expr: LPAREN type_expr RPAREN LBRACE init_exprs RBRACE
 
 init_exprs: init_exprs COMMA init_expr
           | init_expr
-          | 
+          |
 
 // Type expressions
 
 // C standard calls this specifier-qualifier-list
-prim_type: CHAR
+PRIM_TYPE: CHAR
          | SHORT
          | INT
          | LONG
@@ -277,7 +282,7 @@ prim_type: CHAR
          | DOUBLE
          | STRING
 
-basetype: prim_type
+basetype: PRIM_TYPE
         | EVFLAG
         | VOID
         | ENUM NAME
@@ -315,10 +320,9 @@ option_value: ADD
 state_sets: state_sets state_set
           | state_set
 
-state_set: SS NAME LBRACE ss_defns states RBRACE
+state_set: STATE_SET NAME LBRACE ss_defns states RBRACE
 
-ss_defns: ss_defns ss_defn
-        | 
+ss_defns: ss_defn*
 
 ss_defn: assign
        | monitor
@@ -326,13 +330,11 @@ ss_defn: assign
        | syncq
        | declaration
 
-states: states state
-      | state
+states: state*
 
-state: STATE NAME LBRACE state_defns entry transitions exit RBRACE
+state: STATE NAME LBRACE state_defns entry? transitions exit? RBRACE
 
-state_defns: state_defns state_defn
-           | 
+state_defns: state_defn*
 
 state_defn: assign
           | monitor
@@ -342,13 +344,10 @@ state_defn: assign
           | option
 
 entry: ENTRY block
-     | 
 
 exit: EXIT block
-    | 
 
-transitions: transitions transition
-           | transition
+transitions: transition+
 
 transition: WHEN LPAREN condition RPAREN block STATE NAME
           | WHEN LPAREN condition RPAREN block EXIT
@@ -359,7 +358,7 @@ condition: opt_expr
 block: LBRACE block_defns statements RBRACE
 
 block_defns: block_defns block_defn
-           | 
+           |
 
 block_defn: declaration
           | c_code
@@ -367,7 +366,7 @@ block_defn: declaration
 // Statements
 
 statements: statements statement
-          | 
+          |
 
 statement: BREAK SEMICOLON
          | CONTINUE SEMICOLON
@@ -454,13 +453,13 @@ comma_expr: comma_expr COMMA expr
           | expr
 
 opt_expr: comma_expr
-        | 
+        |
 
 // Function arguments
 // Syntactically the same as opt_expr but interpreted differently.
 args: args COMMA expr
     | expr
-    | 
+    |
 
 string: STRCON
 member: NAME
@@ -480,6 +479,5 @@ member_decls: member_decl
 member_decl: basetype declarator SEMICOLON
            | c_code
 
-// Literal  code
-
+// Literal code
 c_code: CCODE

--- a/whatrecord/grammar/snl.lark
+++ b/whatrecord/grammar/snl.lark
@@ -176,22 +176,22 @@ program_param: LPAREN string RPAREN
 
 // Definitions
 
-initial_defns: initial_defn*
-initial_defn: assign
-            | monitor
-            | sync
-            | syncq
-            | declaration
-            | option
-            | c_code
-            | funcdef
-            | structdef
+initial_defns: _initial_defn*
+_initial_defn: assign
+             | monitor
+             | sync
+             | syncq
+             | declaration
+             | option
+             | c_code
+             | funcdef
+             | structdef
 
-final_defns: final_defn*
+final_defns: _final_defn*
 
-final_defn: c_code
-          | funcdef
-          | structdef
+_final_defn: c_code
+           | funcdef
+           | structdef
 
 assign: ASSIGN variable to string SEMICOLON
       | ASSIGN variable subscript to string SEMICOLON
@@ -322,26 +322,26 @@ state_sets: state_sets state_set
 
 state_set: STATE_SET NAME LBRACE ss_defns states RBRACE
 
-ss_defns: ss_defn*
+ss_defns: _ss_defn*
 
-ss_defn: assign
-       | monitor
-       | sync
-       | syncq
-       | declaration
+_ss_defn: assign
+        | monitor
+        | sync
+        | syncq
+        | declaration
 
 states: state*
 
 state: STATE NAME LBRACE state_defns entry? transitions exit? RBRACE
 
-state_defns: state_defn*
+state_defns: _state_defn*
 
-state_defn: assign
-          | monitor
-          | sync
-          | syncq
-          | declaration
-          | option
+_state_defn: assign
+           | monitor
+           | sync
+           | syncq
+           | declaration
+           | option
 
 entry: ENTRY block
 
@@ -357,16 +357,14 @@ condition: opt_expr
 
 block: LBRACE block_defns statements RBRACE
 
-block_defns: block_defns block_defn
-           |
+block_defns: _block_defn*
 
-block_defn: declaration
-          | c_code
+_block_defn: declaration
+           | c_code
 
 // Statements
 
-statements: statements statement
-          |
+statements: statement*
 
 statement: BREAK SEMICOLON
          | CONTINUE SEMICOLON
@@ -452,8 +450,7 @@ integer_literal: INTCON
 comma_expr: comma_expr COMMA expr
           | expr
 
-opt_expr: comma_expr
-        |
+opt_expr: comma_expr?
 
 // Function arguments
 // Syntactically the same as opt_expr but interpreted differently.

--- a/whatrecord/grammar/snl.lark
+++ b/whatrecord/grammar/snl.lark
@@ -170,7 +170,7 @@ CCODE: "%{" /.*?/s "}%"
 
 // The program itself
 
-program: PROGRAM NAME program_param? initial_defns entry? state_sets exit? final_defns
+program: PROGRAM NAME program_param? initial_defns entry state_sets exit final_defns
 
 program_param: LPAREN string RPAREN
 
@@ -193,24 +193,20 @@ _final_defn: c_code
            | funcdef
            | structdef
 
-assign: ASSIGN variable to string SEMICOLON
-      | ASSIGN variable subscript to string SEMICOLON
-      | ASSIGN variable to LBRACE strings RBRACE SEMICOLON
+assign: ASSIGN variable to string SEMICOLON                -> assign_string
+      | ASSIGN variable subscript to string SEMICOLON      -> assign_subscript_string
+      | ASSIGN variable to LBRACE strings RBRACE SEMICOLON -> assign_strings
       | ASSIGN variable SEMICOLON
 
 to: TO?
 
-strings: strings COMMA string
-       | string
-       |
+strings: _comma_separated{string}?
 
 monitor: MONITOR variable opt_subscript SEMICOLON
-// | MONITOR variable opt_subscript error SEMICOLON
 
 sync: SYNC variable opt_subscript to event_flag SEMICOLON
-// | SYNC variable opt_subscript to event_flag error SEMICOLON
 
-syncq: SYNCQ variable opt_subscript to event_flag syncq_size SEMICOLON
+syncq: SYNCQ variable opt_subscript to event_flag syncq_size SEMICOLON -> syncq_flagged
      | SYNCQ variable opt_subscript syncq_size SEMICOLON
 
 event_flag: NAME
@@ -224,32 +220,26 @@ subscript: LBRACKET INTCON RBRACKET
 
 // Declarations
 declaration: basetype init_declarators SEMICOLON
-           | FOREIGN variables SEMICOLON   // Deprecated
+           | FOREIGN variables SEMICOLON          -> foreign_declaration // Deprecated
 
+init_declarators: _comma_separated{init_declarator}
 
-init_declarators: init_declarator
-                | init_declarators COMMA init_declarator
-
-init_declarator: declarator
-               | declarator EQUAL init_expr
+init_declarator: declarator (EQUAL init_expr)?
 
 declarator: variable
-          | declarator subscript
-          | declarator LPAREN param_decls RPAREN
-          | LPAREN declarator RPAREN
-          | ASTERISK declarator
-          | CONST declarator
+          | declarator LPAREN param_decls RPAREN   -> declarator_decls
+          | declarator subscript                   -> declarator_subscript
+          | LPAREN declarator RPAREN               -> declarator_paren
+          | ASTERISK declarator                    -> declarator_deref
+          | CONST declarator                       -> declarator_const
 
-param_decls:
-           | param_decl
-           | param_decls COMMA param_decl
+param_decls: _comma_separated{param_decl}?
 
 // Allow parameter declaration with or without identifier
 param_decl: basetype declarator
           | type_expr
 
-variables: variable
-         | variables COMMA variable
+variables: _comma_separated{variable}
 
 // Initializer
 // Note: comma operator not allowed in 'expr'.
@@ -257,9 +247,7 @@ init_expr: LPAREN type_expr RPAREN LBRACE init_exprs RBRACE
          | LBRACE init_exprs RBRACE
          | expr
 
-init_exprs: init_exprs COMMA init_expr
-          | init_expr
-          |
+init_exprs: _comma_separated{init_expr}?
 
 // Type expressions
 
@@ -290,8 +278,7 @@ basetype: PRIM_TYPE
         | UNION NAME
         | TYPENAME NAME
 
-type_expr: basetype
-         | basetype abs_decl
+type_expr: basetype abs_decl?
 
 // abstract_declarator
 abs_decl: LPAREN abs_decl RPAREN
@@ -317,8 +304,7 @@ option_value: ADD
             | SUB
 
 // State sets and states
-state_sets: state_sets state_set
-          | state_set
+state_sets: state_set+
 
 state_set: STATE_SET NAME LBRACE ss_defns states RBRACE
 
@@ -332,7 +318,7 @@ _ss_defn: assign
 
 states: state*
 
-state: STATE NAME LBRACE state_defns entry? transitions exit? RBRACE
+state: STATE NAME LBRACE state_defns entry transitions exit RBRACE
 
 state_defns: _state_defn*
 
@@ -343,14 +329,13 @@ _state_defn: assign
            | declaration
            | option
 
-entry: ENTRY block
-
-exit: EXIT block
+entry: (ENTRY block)?
+exit: (EXIT block)?
 
 transitions: transition+
 
 transition: WHEN LPAREN condition RPAREN block STATE NAME
-          | WHEN LPAREN condition RPAREN block EXIT
+          | WHEN LPAREN condition RPAREN block EXIT        -> transition_exit
 // | WHEN LPAREN condition RPAREN block error // report("expected 'state' or 'exit'\n");
 
 condition: opt_expr
@@ -366,19 +351,20 @@ _block_defn: declaration
 
 statements: statement*
 
-statement: BREAK SEMICOLON
-         | CONTINUE SEMICOLON
-         | RETURN opt_expr SEMICOLON
-         | STATE NAME SEMICOLON
+statement: BREAK SEMICOLON                              -> break_statement
+         | CONTINUE SEMICOLON                           -> continue_statement
+         | RETURN opt_expr SEMICOLON                    -> return_statement
+         | STATE NAME SEMICOLON                         -> state_statement
          | c_code
          | block
-         | IF LPAREN comma_expr RPAREN statement
-         | IF LPAREN comma_expr RPAREN statement ELSE statement
-         | WHILE LPAREN comma_expr RPAREN statement
+         | if_statement
+         | WHILE LPAREN comma_expr RPAREN statement     -> while_statement
          | for_statement
-         | opt_expr SEMICOLON
+         | opt_expr SEMICOLON                           -> expr_statement
 //       | error SEMICOLON(t).
 
+
+if_statement: IF LPAREN comma_expr RPAREN statement (ELSE statement)?
 
 for_statement: FOR LPAREN opt_expr SEMICOLON opt_expr SEMICOLON opt_expr RPAREN statement
 
@@ -392,71 +378,78 @@ floating_point_literal: FPCON
 integer_literal: INTCON
 
 // Atomic
-?expr: integer_literal
-     | floating_point_literal
-     | string
-     | variable
-     | LPAREN comma_expr RPAREN // Primary Expression and Unary Postfix Operators
-     | expr LPAREN args RPAREN
-     | EXIT LPAREN args RPAREN
-     | SIZEOF LPAREN type_expr RPAREN
-     | expr LBRACKET expr RBRACKET
-     | expr PERIOD member
-     | expr POINTER member
-     | expr INCR
-     | expr DECR
-     | ADD   expr   // Unary Prefix Operators
-     | SUB   expr
-     | ASTERISK  expr
-     | AMPERSAND expr
-     | NOT   expr
-     | TILDE expr
-     | INCR  expr
-     | DECR  expr
-     | SIZEOF    expr
-     | LPAREN type_expr RPAREN expr   // type cast
-     | expr SUB expr  // Binary Operators, left-to-right
-     | expr ADD expr
-     | expr ASTERISK expr
-     | expr SLASH expr
-     | expr GT expr
-     | expr GE expr
-     | expr EQ expr
-     | expr NE expr
-     | expr LE expr
-     | expr LT expr
-     | expr OROR expr
-     | expr ANDAND expr
-     | expr LSHIFT expr
-     | expr RSHIFT expr
-     | expr VBAR expr
-     | expr CARET expr
-     | expr AMPERSAND expr
-     | expr MOD expr
-     | expr QUESTION expr COLON expr
-     | expr EQUAL expr
-     | expr ADDEQ expr
-     | expr SUBEQ expr
-     | expr ANDEQ expr
-     | expr OREQ expr
-     | expr DIVEQ expr
-     | expr MULEQ expr
-     | expr MODEQ expr
-     | expr LSHEQ expr
-     | expr RSHEQ expr
-     | expr XOREQ expr
+?expr: literal_expr
+     | LPAREN comma_expr RPAREN       -> parenthesized_expr
+     | expr LPAREN args RPAREN        -> expr_with_args
+     | expr LBRACKET expr RBRACKET    -> bracket_expr
+     | EXIT LPAREN args RPAREN        -> exit_expr
+     | SIZEOF LPAREN type_expr RPAREN -> sizeof
+     | unary_postfix_expr
+     | unary_prefix_expr
+     | binary_operator_expr
+     | LPAREN type_expr RPAREN expr   -> type_cast_expr
+     | expr QUESTION expr COLON expr  -> ternary_expr
+
+
+member_expr: expr PERIOD member
+           | expr POINTER member
+
+literal_expr: integer_literal
+            | floating_point_literal
+            | string
+            | variable
+
+unary_postfix_expr: expr INCR
+                  | expr DECR
+
+unary_prefix_expr: ADD expr   // Unary Prefix Operators
+                 | SUB expr
+                 | ASTERISK expr
+                 | AMPERSAND expr
+                 | NOT expr
+                 | TILDE expr
+                 | INCR expr
+                 | DECR expr
+                 | SIZEOF expr
+
+binary_operator_expr: expr SUB expr  // Binary Operators, left-to-right
+                    | expr ADD expr
+                    | expr ASTERISK expr
+                    | expr SLASH expr
+                    | expr GT expr
+                    | expr GE expr
+                    | expr EQ expr
+                    | expr NE expr
+                    | expr LE expr
+                    | expr LT expr
+                    | expr OROR expr
+                    | expr ANDAND expr
+                    | expr LSHIFT expr
+                    | expr RSHIFT expr
+                    | expr VBAR expr
+                    | expr CARET expr
+                    | expr AMPERSAND expr
+                    | expr MOD expr
+                    | expr EQUAL expr
+                    | expr ADDEQ expr
+                    | expr SUBEQ expr
+                    | expr ANDEQ expr
+                    | expr OREQ expr
+                    | expr DIVEQ expr
+                    | expr MULEQ expr
+                    | expr MODEQ expr
+                    | expr LSHEQ expr
+                    | expr RSHEQ expr
+                    | expr XOREQ expr
 
 // Comma, left-to-right
-comma_expr: comma_expr COMMA expr
-          | expr
+comma_expr: _comma_separated{expr}
 
 opt_expr: comma_expr?
 
 // Function arguments
 // Syntactically the same as opt_expr but interpreted differently.
-args: args COMMA expr
-    | expr
-    |
+args: _comma_separated{expr}?
 
 string: STRCON
 member: NAME
@@ -470,11 +463,12 @@ structdef: STRUCT NAME members SEMICOLON
 
 members: LBRACE member_decls RBRACE
 
-member_decls: member_decl
-            | member_decls member_decl
+member_decls: member_decl+
 
 member_decl: basetype declarator SEMICOLON
-           | c_code
+           | c_code                          -> member_decl_ccode
 
 // Literal code
 c_code: CCODE
+
+_comma_separated{x}: x ( "," x )*

--- a/whatrecord/grammar/snl.lark
+++ b/whatrecord/grammar/snl.lark
@@ -170,9 +170,9 @@ CCODE: "%{" /.*?/s "}%"
 
 // The program itself
 
-program: PROGRAM NAME program_param? initial_defns entry state_sets exit final_defns
+program: PROGRAM NAME program_param initial_defns entry state_sets exit final_defns
 
-program_param: LPAREN string RPAREN
+program_param: (LPAREN string RPAREN)?
 
 // Definitions
 
@@ -243,8 +243,8 @@ variables: _comma_separated{variable}
 
 // Initializer
 // Note: comma operator not allowed in 'expr'.
-init_expr: LPAREN type_expr RPAREN LBRACE init_exprs RBRACE
-         | LBRACE init_exprs RBRACE
+init_expr: LPAREN type_expr RPAREN LBRACE init_exprs RBRACE -> typed_init_expr
+         | LBRACE init_exprs RBRACE                         -> untyped_init_expr
          | expr
 
 init_exprs: _comma_separated{init_expr}?
@@ -252,25 +252,25 @@ init_exprs: _comma_separated{init_expr}?
 // Type expressions
 
 // C standard calls this specifier-qualifier-list
-PRIM_TYPE: CHAR
-         | SHORT
-         | INT
-         | LONG
-         | UNSIGNED CHAR
-         | UNSIGNED SHORT
-         | UNSIGNED INT
-         | UNSIGNED LONG
-         | INT8T
-         | UINT8T
-         | INT16T
-         | UINT16T
-         | INT32T
-         | UINT32T
-         | FLOAT
-         | DOUBLE
-         | STRING
+_prim_type: CHAR
+          | SHORT
+          | INT
+          | LONG
+          | UNSIGNED CHAR
+          | UNSIGNED SHORT
+          | UNSIGNED INT
+          | UNSIGNED LONG
+          | INT8T
+          | UINT8T
+          | INT16T
+          | UINT16T
+          | INT32T
+          | UINT32T
+          | FLOAT
+          | DOUBLE
+          | STRING
 
-basetype: PRIM_TYPE
+basetype: _prim_type
         | EVFLAG
         | VOID
         | ENUM NAME
@@ -281,15 +281,14 @@ basetype: PRIM_TYPE
 type_expr: basetype abs_decl?
 
 // abstract_declarator
-abs_decl: LPAREN abs_decl RPAREN
-        | ASTERISK
-        | ASTERISK abs_decl
-        | CONST
-        | CONST abs_decl
-        | subscript
-        | abs_decl subscript
-        | LPAREN param_decls RPAREN
-        | abs_decl LPAREN param_decls RPAREN
+abs_decl: abs_decl_mod
+        | abs_decl? subscript                  -> abs_decl_subscript
+        | abs_decl? LPAREN param_decls RPAREN  -> abs_decl_params
+
+// abstract declarator with some modification (), *, const
+abs_decl_mod: LPAREN abs_decl RPAREN
+            | ASTERISK abs_decl?
+            | CONST abs_decl?
 
 // not supported: empty brackets, empty parameter list
 // abs_decl: LBRACKET RBRACKET
@@ -384,6 +383,7 @@ integer_literal: INTCON
      | expr LBRACKET expr RBRACKET    -> bracket_expr
      | EXIT LPAREN args RPAREN        -> exit_expr
      | SIZEOF LPAREN type_expr RPAREN -> sizeof
+     | member_expr
      | unary_postfix_expr
      | unary_prefix_expr
      | binary_operator_expr
@@ -391,13 +391,12 @@ integer_literal: INTCON
      | expr QUESTION expr COLON expr  -> ternary_expr
 
 
-member_expr: expr PERIOD member
-           | expr POINTER member
+member_expr: expr (PERIOD | POINTER) member
 
 literal_expr: integer_literal
             | floating_point_literal
             | string
-            | variable
+            | variable                -> variable_literal
 
 unary_postfix_expr: expr INCR
                   | expr DECR

--- a/whatrecord/grammar/snl.lark
+++ b/whatrecord/grammar/snl.lark
@@ -13,8 +13,8 @@
 WHITESPACE: /[ \t\v\f]+/
 %ignore WHITESPACE
 
-MULTI_LINE_COMMENT: "/*" /./s* "*/"
-SINGLE_LINE_COMMENT: "//" /[^\n]/*
+MULTI_LINE_COMMENT: "/*" /.*?/s "*/"
+SINGLE_LINE_COMMENT: "//" /.*/
 
 COMMENT: MULTI_LINE_COMMENT
        | SINGLE_LINE_COMMENT
@@ -165,12 +165,12 @@ STRCON: "\"" (ESC | /[^"\n\\]/)* "\""
 LINE_MARKER: DEC+ SPC*
            | "\"" (ESC | /[^\n\\"]/)* "\""
 
-CCODE: "%{" /./s* "}%"
+CCODE: "%{" /.*?/s "}%"
      | "%%" /[^\n]*/
 
 // The program itself
 
-program: PROGRAM NAME program_param? initial_defns entry state_sets exit final_defns
+program: PROGRAM NAME program_param? initial_defns entry? state_sets exit? final_defns
 
 program_param: LPAREN string RPAREN
 

--- a/whatrecord/grammar/snl.lark
+++ b/whatrecord/grammar/snl.lark
@@ -1,0 +1,485 @@
+// Attempt at a state notation language (snl/seq) grammar
+//
+// snl itself uses re2c and an LALR-based lemon grammar.
+
+?start: program
+
+%import common.WS
+%ignore WS
+
+WHITESPACE: /[ \t\v\f]+/
+%ignore WHITESPACE
+
+MULTI_LINE_COMMENT: /\/\*.*?\*\//s
+SINGLE_LINE_COMMENT: "//" /[^\n]/*
+
+%ignore MULTI_LINE_COMMENT
+%ignore SINGLE_LINE_COMMENT
+
+NL: /[\n]/
+ANY: /[^]/
+SPC: /[ \t]/
+OCT: /[0-7]/
+DEC: /[0-9]/
+LET: /[a-zA-Z_]/
+HEX: /[a-fA-F0-9]/
+EXP: /[Ee]/ /[+-]?/ DEC+
+FS: /[fFlL]/
+IS: /[uUlL]*/
+ESC: "\\" (/[abfnrtv?'"\\]/ | "x" HEX+ | OCT+)
+LINE: SPC* "#" (SPC* "line")? SPC+
+
+ASSIGN: "assign"
+BREAK: "break"
+CONTINUE: "continue"
+ELSE: "else"
+ENTRY: "entry"
+EXIT: "exit"
+FOR: "for"
+IF: "if"
+MONITOR: "monitor"
+OPTION: "option"
+PROGRAM: "program"
+RETURN: "return"
+SS: "ss"
+STATE: "state"
+STRING: "string"
+SYNCQ: "syncQ"
+     | "syncq"
+SYNC: "sync"
+TO: "to"
+WHEN: "when"
+WHILE: "while"
+
+CHAR: "char"
+CONST: "const"
+DOUBLE: "double"
+ENUM: "enum"
+EVFLAG: "evflag"
+FLOAT: "float"
+FOREIGN: "foreign"
+INT: "int"
+LONG: "long"
+SHORT: "short"
+SIZEOF: "sizeof"
+STRUCT: "struct"
+TYPENAME: "typename"
+UNION: "union"
+UNSIGNED: "unsigned"
+VOID: "void"
+INT8T: "int8_t"
+UINT8T: "uint8_t"
+INT16T: "int16_t"
+UINT16T: "uint16_t"
+INT32T: "int32_t"
+UINT32T: "uint32_t"
+
+TYPEWORD: CHAR | CONST | DOUBLE | ENUM | EVFLAG | FLOAT | FOREIGN | INT 
+        | INT16T | INT32T | INT8T | LONG | SHORT | SIZEOF | STRUCT 
+        | TYPENAME | UINT16T | UINT32T | UINT8T | UNION | UNSIGNED | VOID
+
+// "seqg_" (LET|DEC)*  -> "identifier '%s'starts with reserved prefix\n"
+
+NAME: LET (LET|DEC)*
+
+// integer_literal
+INTCON: "0" "x"i HEX+ IS?
+      | "0" OCT+ IS?
+      | DEC+ IS?
+      | "'" ( ESC | /[^\n\\']/ )* "'"
+
+// floating_point_literal
+FPCON: DEC+ EXP FS?
+     | DEC* PERIOD DEC+ EXP? FS?
+     | DEC+ PERIOD DEC* EXP? FS?
+
+RSHEQ: ">>="
+LSHEQ: "<<="
+ADDEQ: "+="
+SUBEQ: "-="
+MULEQ: "*="
+DIVEQ: "/="
+MODEQ: "%="
+ANDEQ: "&="
+XOREQ: "^="
+OREQ: "|="
+RSHIFT: ">>"
+LSHIFT: "<<"
+INCR: "++"
+DECR: "--"
+POINTER: "->"
+ANDAND: "&&"
+OROR: "||"
+LE: "<="
+GE: ">="
+EQ: "=="
+NE: "!="
+COLON: ":"
+EQUAL: "="
+PERIOD: "."
+AMPERSAND: "&"
+NOT: "!"
+TILDE: "~"
+SUB: "-"
+ADD: "+"
+ASTERISK: "*"
+SLASH: "/"
+MOD: "%"
+LT: "<"
+GT: ">"
+CARET: "^"
+VBAR: "|"
+QUESTION: "?"
+
+OPERATOR: RSHEQ | LSHEQ | ADDEQ | SUBEQ | MULEQ | DIVEQ | MODEQ | ANDEQ | XOREQ | OREQ
+        | RSHIFT | LSHIFT | INCR | DECR
+        | POINTER
+        | ANDAND | OROR
+        | LE | GE | EQ | NE
+        | COLON
+        | EQUAL | PERIOD | AMPERSAND
+        | NOT | TILDE | SUB | ADD
+        | ASTERISK | SLASH | MOD | LT | GT
+        | CARET | VBAR | QUESTION
+
+SEMICOLON: ";"
+LBRACE: "{"
+RBRACE: "}"
+COMMA: ","
+LPAREN: "("
+RPAREN: ")"
+LBRACKET: "["
+RBRACKET: "]"
+
+DELIMITER: SEMICOLON | LBRACE | RBRACE | COMMA | LPAREN | RPAREN | LBRACKET | RBRACKET
+
+// string_const
+STRCON: "\"" (ESC | /[^"\n\\]/)* "\""
+
+
+LINE_MARKER: DEC+ SPC*
+           | "\"" (ESC | /[^\n\\"]/)* "\""
+
+CCODE: "%{" /./* "}%"
+     | "%%" /[^\n]/*
+
+// The program itself
+
+program: PROGRAM NAME program_param? initial_defns entry state_sets exit final_defns
+
+program_param: LPAREN string RPAREN
+
+// Definitions
+
+initial_defns: initial_defn*
+initial_defn: assign
+            | monitor
+            | sync
+            | syncq
+            | declaration
+            | option
+            | c_code
+            | funcdef
+            | structdef
+
+final_defns: final_defn*
+
+final_defn: c_code
+          | funcdef
+          | structdef
+
+assign: ASSIGN variable to string SEMICOLON
+      | ASSIGN variable subscript to string SEMICOLON
+      | ASSIGN variable to LBRACE strings RBRACE SEMICOLON
+      | ASSIGN variable SEMICOLON
+
+to: TO?
+
+strings: strings COMMA string
+       | string
+       | 
+
+monitor: MONITOR variable opt_subscript SEMICOLON
+// | MONITOR variable opt_subscript error SEMICOLON
+
+sync: SYNC variable opt_subscript to event_flag SEMICOLON
+// | SYNC variable opt_subscript to event_flag error SEMICOLON
+
+syncq: SYNCQ variable opt_subscript to event_flag syncq_size SEMICOLON
+     | SYNCQ variable opt_subscript syncq_size SEMICOLON
+
+event_flag: NAME
+variable: NAME
+
+syncq_size: INTCON?
+
+opt_subscript: subscript?
+
+subscript: LBRACKET INTCON RBRACKET
+
+// Declarations
+declaration: basetype init_declarators SEMICOLON
+           | FOREIGN variables SEMICOLON   // Deprecated
+
+
+init_declarators: init_declarator
+                | init_declarators COMMA init_declarator
+
+init_declarator: declarator
+               | declarator EQUAL init_expr
+
+declarator: variable
+          | declarator subscript
+          | declarator LPAREN param_decls RPAREN
+          | LPAREN declarator RPAREN
+          | ASTERISK declarator
+          | CONST declarator
+
+param_decls: 
+           | param_decl
+           | param_decls COMMA param_decl
+
+// Allow parameter declaration with or without identifier
+param_decl: basetype declarator
+          | type_expr
+
+variables: variable
+         | variables COMMA variable
+
+// Initializer
+// Note: comma operator not allowed in 'expr'.
+init_expr: LPAREN type_expr RPAREN LBRACE init_exprs RBRACE
+         | LBRACE init_exprs RBRACE
+         | expr
+
+init_exprs: init_exprs COMMA init_expr
+          | init_expr
+          | 
+
+// Type expressions
+
+// C standard calls this specifier-qualifier-list
+prim_type: CHAR
+         | SHORT
+         | INT
+         | LONG
+         | UNSIGNED CHAR
+         | UNSIGNED SHORT
+         | UNSIGNED INT
+         | UNSIGNED LONG
+         | INT8T
+         | UINT8T
+         | INT16T
+         | UINT16T
+         | INT32T
+         | UINT32T
+         | FLOAT
+         | DOUBLE
+         | STRING
+
+basetype: prim_type
+        | EVFLAG
+        | VOID
+        | ENUM NAME
+        | STRUCT NAME
+        | UNION NAME
+        | TYPENAME NAME
+
+type_expr: basetype
+         | basetype abs_decl
+
+// abstract_declarator
+abs_decl: LPAREN abs_decl RPAREN
+        | ASTERISK
+        | ASTERISK abs_decl
+        | CONST
+        | CONST abs_decl
+        | subscript
+        | abs_decl subscript
+        | LPAREN param_decls RPAREN
+        | abs_decl LPAREN param_decls RPAREN
+
+// not supported: empty brackets, empty parameter list
+// abs_decl: LBRACKET RBRACKET
+//         | abs_decl LBRACKET RBRACKET
+//         | LPAREN RPAREN
+//         | abs_decl LPAREN RPAREN
+
+// Option spec
+option: OPTION option_value NAME SEMICOLON
+
+option_value: ADD
+            | SUB
+
+// State sets and states
+state_sets: state_sets state_set
+          | state_set
+
+state_set: SS NAME LBRACE ss_defns states RBRACE
+
+ss_defns: ss_defns ss_defn
+        | 
+
+ss_defn: assign
+       | monitor
+       | sync
+       | syncq
+       | declaration
+
+states: states state
+      | state
+
+state: STATE NAME LBRACE state_defns entry transitions exit RBRACE
+
+state_defns: state_defns state_defn
+           | 
+
+state_defn: assign
+          | monitor
+          | sync
+          | syncq
+          | declaration
+          | option
+
+entry: ENTRY block
+     | 
+
+exit: EXIT block
+    | 
+
+transitions: transitions transition
+           | transition
+
+transition: WHEN LPAREN condition RPAREN block STATE NAME
+          | WHEN LPAREN condition RPAREN block EXIT
+// | WHEN LPAREN condition RPAREN block error // report("expected 'state' or 'exit'\n");
+
+condition: opt_expr
+
+block: LBRACE block_defns statements RBRACE
+
+block_defns: block_defns block_defn
+           | 
+
+block_defn: declaration
+          | c_code
+
+// Statements
+
+statements: statements statement
+          | 
+
+statement: BREAK SEMICOLON
+         | CONTINUE SEMICOLON
+         | RETURN opt_expr SEMICOLON
+         | STATE NAME SEMICOLON
+         | c_code
+         | block
+         | IF LPAREN comma_expr RPAREN statement
+         | IF LPAREN comma_expr RPAREN statement ELSE statement
+         | WHILE LPAREN comma_expr RPAREN statement
+         | for_statement
+         | opt_expr SEMICOLON
+//       | error SEMICOLON(t).
+
+
+for_statement: FOR LPAREN opt_expr SEMICOLON opt_expr SEMICOLON opt_expr RPAREN statement
+
+// Expressions
+
+// Note: the non-terminal 'expr' does not include application of the comma operator.
+// Comma separated lists of 'expr' can be: function arguments (non-terminal
+// 'args')and applications of the comma operator (non-terminal 'comma_expr').
+
+floating_point_literal: FPCON
+integer_literal: INTCON
+
+// Atomic
+?expr: integer_literal
+     | floating_point_literal
+     | string
+     | variable
+     | LPAREN comma_expr RPAREN // Primary Expression and Unary Postfix Operators
+     | expr LPAREN args RPAREN
+     | EXIT LPAREN args RPAREN
+     | SIZEOF LPAREN type_expr RPAREN
+     | expr LBRACKET expr RBRACKET
+     | expr PERIOD member
+     | expr POINTER member
+     | expr INCR
+     | expr DECR
+     | ADD   expr   // Unary Prefix Operators
+     | SUB   expr
+     | ASTERISK  expr
+     | AMPERSAND expr
+     | NOT   expr
+     | TILDE expr
+     | INCR  expr
+     | DECR  expr
+     | SIZEOF    expr
+     | LPAREN type_expr RPAREN expr   // type cast
+     | expr SUB expr  // Binary Operators, left-to-right
+     | expr ADD expr
+     | expr ASTERISK expr
+     | expr SLASH expr
+     | expr GT expr
+     | expr GE expr
+     | expr EQ expr
+     | expr NE expr
+     | expr LE expr
+     | expr LT expr
+     | expr OROR expr
+     | expr ANDAND expr
+     | expr LSHIFT expr
+     | expr RSHIFT expr
+     | expr VBAR expr
+     | expr CARET expr
+     | expr AMPERSAND expr
+     | expr MOD expr
+     | expr QUESTION expr COLON expr
+     | expr EQUAL expr
+     | expr ADDEQ expr
+     | expr SUBEQ expr
+     | expr ANDEQ expr
+     | expr OREQ expr
+     | expr DIVEQ expr
+     | expr MULEQ expr
+     | expr MODEQ expr
+     | expr LSHEQ expr
+     | expr RSHEQ expr
+     | expr XOREQ expr
+
+// Comma, left-to-right
+comma_expr: comma_expr COMMA expr
+          | expr
+
+opt_expr: comma_expr
+        | 
+
+// Function arguments
+// Syntactically the same as opt_expr but interpreted differently.
+args: args COMMA expr
+    | expr
+    | 
+
+string: STRCON
+member: NAME
+
+// Function Definitions
+funcdef: basetype declarator block
+
+// Struct Definitions
+
+structdef: STRUCT NAME members SEMICOLON
+
+members: LBRACE member_decls RBRACE
+
+member_decls: member_decl
+            | member_decls member_decl
+
+member_decl: basetype declarator SEMICOLON
+           | c_code
+
+// Literal  code
+
+c_code: CCODE

--- a/whatrecord/snl.py
+++ b/whatrecord/snl.py
@@ -52,6 +52,8 @@ class SequencerProgram:
                     )
             elif line.startswith("#if"):
                 ...  # sorry; this may break things
+            elif line.startswith("#else"):
+                ...  # sorry; this may break things
             elif line.startswith("#elif"):
                 ...  # sorry; this may break things
             elif line.startswith("#endif"):

--- a/whatrecord/snl.py
+++ b/whatrecord/snl.py
@@ -223,9 +223,12 @@ class Variable(Expression):
 
 @dataclass
 class InitExpression(Expression):
-    # ( type ) { init_exprs }
-    # { init_exprs }
-    # expr
+    """
+    Of the form:
+        ( type ) { init_exprs }
+        { init_exprs }
+        expr
+    """
     # TODO: may be improved?
     context: FullLoadContext
     expressions: Tuple[Union[InitExpression, Expression], ...] = field(default_factory=tuple)
@@ -440,7 +443,9 @@ class _ProgramTransformer(lark.visitors.Transformer):
         exit: Block,
         final_defns: Tuple[Definition, ...],
     ):
-        # PROGRAM NAME program_param initial_defns entry state_sets exit final_defns
+        """
+        PROGRAM NAME program_param initial_defns entry state_sets exit final_defns
+        """
         return self.cls(
             context=context_from_token(self.fn, program_token),
             params=program_param,
@@ -455,21 +460,27 @@ class _ProgramTransformer(lark.visitors.Transformer):
     def program_param(self, *args):
         if not args:
             return None
-        # LPAREN string RPAREN
+        """
+        LPAREN string RPAREN
+        """
         return str(args[1])
 
     initial_defns = transformer.tuple_args
     final_defns = transformer.tuple_args
 
     def assign(self, assign_token, variable, _):
-        # ASSIGN variable SEMICOLON
+        """
+        ASSIGN variable SEMICOLON
+        """
         return Assignment(
             context=context_from_token(self.fn, assign_token),
             variable=str(variable),
         )
 
     def assign_string(self, assign_token, variable, to_, value, _):
-        # ASSIGN variable to string SEMICOLON
+        """
+        ASSIGN variable to string SEMICOLON
+        """
         return Assignment(
             context=context_from_token(self.fn, assign_token),
             variable=str(variable),
@@ -477,7 +488,9 @@ class _ProgramTransformer(lark.visitors.Transformer):
         )
 
     def assign_subscript_string(self, assign_token, variable, subscript, to_, value, _):
-        # ASSIGN variable subscript to string SEMICOLON
+        """
+        ASSIGN variable subscript to string SEMICOLON
+        """
         return Assignment(
             context=context_from_token(self.fn, assign_token),
             variable=str(variable),
@@ -486,7 +499,9 @@ class _ProgramTransformer(lark.visitors.Transformer):
         )
 
     def assign_strings(self, assign_token, variable, to_, _, strings, *__):
-        # ASSIGN variable to LBRACE strings RBRACE SEMICOLON
+        """
+        ASSIGN variable to LBRACE strings RBRACE SEMICOLON
+        """
         return Assignment(
             context=context_from_token(self.fn, assign_token),
             variable=str(variable),
@@ -496,7 +511,9 @@ class _ProgramTransformer(lark.visitors.Transformer):
     strings = transformer.tuple_args
 
     def monitor(self, monitor_token, variable, opt_subscript, _):
-        # MONITOR variable opt_subscript SEMICOLON
+        """
+        MONITOR variable opt_subscript SEMICOLON
+        """
         return Monitor(
             context=context_from_token(self.fn, monitor_token),
             variable=str(variable),
@@ -504,7 +521,9 @@ class _ProgramTransformer(lark.visitors.Transformer):
         )
 
     def sync(self, sync_token, variable, subscript, _, event_flag, __):
-        # SYNC variable opt_subscript to event_flag SEMICOLON
+        """
+        SYNC variable opt_subscript to event_flag SEMICOLON
+        """
         return Sync(
             context=context_from_token(self.fn, sync_token),
             variable=str(variable),
@@ -514,7 +533,9 @@ class _ProgramTransformer(lark.visitors.Transformer):
         )
 
     def syncq_flagged(self, syncq_token, variable, subscript, _, event_flag, syncq_size, __):
-        # SYNCQ variable opt_subscript to event_flag syncq_size SEMICOLON
+        """
+        SYNCQ variable opt_subscript to event_flag syncq_size SEMICOLON
+        """
         return Sync(
             context=context_from_token(self.fn, syncq_token),
             variable=str(variable),
@@ -525,7 +546,9 @@ class _ProgramTransformer(lark.visitors.Transformer):
         )
 
     def syncq(self, syncq_token, variable, subscript, syncq_size, _):
-        # SYNCQ variable opt_subscript syncq_size SEMICOLON
+        """
+        SYNCQ variable opt_subscript syncq_size SEMICOLON
+        """
         return Sync(
             context=context_from_token(self.fn, syncq_token),
             variable=str(variable),
@@ -538,17 +561,23 @@ class _ProgramTransformer(lark.visitors.Transformer):
     variable = transformer.pass_through
 
     def syncq_size(self, size=None):
-        # INTCON?
+        """
+        INTCON?
+        """
         return int(size) if size else None
 
     opt_subscript = transformer.pass_through
 
     def subscript(self, _, value, __):
-        # LBRACKET INTCON RBRACKET
+        """
+        LBRACKET INTCON RBRACKET
+        """
         return value
 
     def declaration(self, basetype: Type, init_declarators, _):
-        # basetype init_declarators SEMICOLON
+        """
+        basetype init_declarators SEMICOLON
+        """
         return Declaration(
             context=basetype.context,
             type=basetype,
@@ -556,7 +585,9 @@ class _ProgramTransformer(lark.visitors.Transformer):
         )
 
     def foreign_declaration(self, foreign_token, variables, _):
-        # FOREIGN variables SEMICOLON
+        """
+        FOREIGN variables SEMICOLON
+        """
         return ForeignDeclaration(
             context=context_from_token(self.fn, foreign_token),
             names=tuple(str(variable) for variable in variables),
@@ -619,8 +650,10 @@ class _ProgramTransformer(lark.visitors.Transformer):
     param_decls = transformer.tuple_args
 
     def param_decl(self, type_, declarator=None):
-        # basetype declarator
-        # type_expr
+        """
+        basetype declarator
+        type_expr
+        """
         return ParameterDeclarator(
             context=type_.context,
             type=type_,
@@ -632,8 +665,10 @@ class _ProgramTransformer(lark.visitors.Transformer):
     init_expr = transformer.pass_through
 
     def typed_init_expr(self, lparen, type_expr, _, __, init_exprs, ___):
-        # LPAREN type_expr RPAREN LBRACE init_exprs RBRACE
-        # LBRACE init_exprs RBRACE
+        """
+        type_expr RPAREN LBRACE init_exprs RBRACE
+        LBRACE init_exprs RBRACE
+        """
         return InitExpression(
             context=context_from_token(self.fn, lparen),
             expressions=init_exprs,
@@ -641,7 +676,9 @@ class _ProgramTransformer(lark.visitors.Transformer):
         )
 
     def untyped_init_expr(self, lbrace, init_exprs, _):
-        # LBRACE init_exprs RBRACE
+        """
+        LBRACE init_exprs RBRACE
+        """
         return InitExpression(
             context=context_from_token(self.fn, lbrace),
             expressions=init_exprs,
@@ -661,9 +698,11 @@ class _ProgramTransformer(lark.visitors.Transformer):
         return basetype
 
     def abs_decl_mod(self, token, abs_decl=None, *_):
-        # LPAREN abs_decl RPAREN
-        # ASTERISK abs_decl?
-        # CONST abs_decl?
+        """
+        LPAREN abs_decl RPAREN
+        ASTERISK abs_decl?
+        CONST abs_decl?
+        """
         if abs_decl is not None:
             abs_decl.modifier = str(token)
             return abs_decl
@@ -684,7 +723,9 @@ class _ProgramTransformer(lark.visitors.Transformer):
         return decl
 
     def abs_decl_params(self, *args):
-        # abs_decl? LPAREN param_decls RPAREN
+        """
+        abs_decl? LPAREN param_decls RPAREN
+        """
         # TODO I think these may be wrong
         if len(args) == 4:
             abs_decl, lparen, param_decls, _ = args
@@ -698,7 +739,9 @@ class _ProgramTransformer(lark.visitors.Transformer):
         )
 
     def option(self, option_token, value, name, _):
-        # OPTION option_value NAME SEMICOLON
+        """
+        OPTION option_value NAME SEMICOLON
+        """
         return Option(
             context=context_from_token(self.fn, option_token),
             name=str(name),
@@ -709,7 +752,9 @@ class _ProgramTransformer(lark.visitors.Transformer):
     state_sets = transformer.tuple_args
 
     def state_set(self, state_set_token, name, _, defns, states, __):
-        # STATE_SET NAME LBRACE ss_defns states RBRACE
+        """
+        STATE_SET NAME LBRACE ss_defns states RBRACE
+        """
         return StateSet(
             context=context_from_token(self.fn, state_set_token),
             name=str(name),
@@ -732,7 +777,9 @@ class _ProgramTransformer(lark.visitors.Transformer):
         exit: Block,
         __,
     ):
-        # STATE NAME LBRACE state_defns entry? transitions exit? RBRACE
+        """
+        STATE NAME LBRACE state_defns entry? transitions exit? RBRACE
+        """
         return State(
             context=context_from_token(self.fn, state_token),
             name=str(name),
@@ -763,7 +810,9 @@ class _ProgramTransformer(lark.visitors.Transformer):
         ___,
         state: lark.Token,
     ):
-        # WHEN LPAREN condition RPAREN block STATE NAME
+        """
+        WHEN LPAREN condition RPAREN block STATE NAME
+        """
         return Transition(
             context=context_from_token(self.fn, when),
             condition=condition[0] if condition else None,
@@ -772,7 +821,9 @@ class _ProgramTransformer(lark.visitors.Transformer):
         )
 
     def transition_exit(self, when: lark.Token, _, condition: Expression, __, block: Block, ___):
-        # WHEN LPAREN condition RPAREN block EXIT
+        """
+        WHEN LPAREN condition RPAREN block EXIT
+        """
         return ExitTransition(
             context=context_from_token(self.fn, when),
             condition=condition,
@@ -782,7 +833,9 @@ class _ProgramTransformer(lark.visitors.Transformer):
     condition = transformer.pass_through
 
     def block(self, lbrace: lark.Token, definitions, statements, _):
-        # LBRACE block_defns statements RBRACE
+        """
+        LBRACE block_defns statements RBRACE
+        """
         return Block(
             context=context_from_token(self.fn, lbrace),
             definitions=definitions,
@@ -851,7 +904,9 @@ class _ProgramTransformer(lark.visitors.Transformer):
         else:
             else_body = None
 
-        # IF LPAREN comma_expr RPAREN statement (ELSE statement)?
+        """
+        IF LPAREN comma_expr RPAREN statement (ELSE statement)?
+        """
         return IfStatement(
             context=context_from_token(self.fn, if_token),
             condition=condition,
@@ -871,7 +926,9 @@ class _ProgramTransformer(lark.visitors.Transformer):
         ____,
         statement: Statement,
     ):
-        # FOR LPAREN opt_expr SEMICOLON opt_expr SEMICOLON opt_expr RPAREN statement
+        """
+        FOR LPAREN opt_expr SEMICOLON opt_expr SEMICOLON opt_expr RPAREN statement
+        """
         return ForStatement(
             context=context_from_token(self.fn, for_token),
             init=init,
@@ -992,7 +1049,9 @@ class _ProgramTransformer(lark.visitors.Transformer):
     member = transformer.pass_through
 
     def funcdef(self, basetype: Type, declarator: Declarator, block: Block):
-        # basetype declarator block
+        """
+        basetype declarator block
+        """
         return FuncDef(
             context=basetype.context,
             type=basetype,
@@ -1001,7 +1060,9 @@ class _ProgramTransformer(lark.visitors.Transformer):
         )
 
     def structdef(self, struct_token, name, members, _):
-        # STRUCT NAME members SEMICOLON
+        """
+        STRUCT NAME members SEMICOLON
+        """
         return StructDef(
             context=context_from_token(self.fn, struct_token),
             name=str(name),
@@ -1009,13 +1070,17 @@ class _ProgramTransformer(lark.visitors.Transformer):
         )
 
     def members(self, _, decls, __):
-        # LBRACE member_decls RBRACE
+        """
+        LBRACE member_decls RBRACE
+        """
         return decls
 
     member_decls = transformer.tuple_args
 
     def member_decl(self, type: Type, declarator: Declarator, _):
-        # basetype declarator SEMICOLON
+        """
+        basetype declarator SEMICOLON
+        """
         return StructMember(
             context=type.context,
             type=type,

--- a/whatrecord/snl.py
+++ b/whatrecord/snl.py
@@ -229,9 +229,12 @@ class InitExpression(Expression):
         { init_exprs }
         expr
     """
+
     # TODO: may be improved?
     context: FullLoadContext
-    expressions: Tuple[Union[InitExpression, Expression], ...] = field(default_factory=tuple)
+    expressions: Tuple[Union[InitExpression, Expression], ...] = field(
+        default_factory=tuple
+    )
     type: Optional[Type] = None
 
 
@@ -310,6 +313,7 @@ class ExpressionWithArguments(Expression):
 @dataclass
 class SequencerProgram:
     """Representation of a state notation language (snl seq) program."""
+
     context: FullLoadContext
     name: str
     params: Optional[str]
@@ -329,12 +333,7 @@ class SequencerProgram:
         # with lark...
         search_path = pathlib.Path("." if search_path is None else search_path)
         result = []
-        stack = collections.deque(
-            [
-                (search_path, line)
-                for line in code.splitlines()
-            ]
-        )
+        stack = collections.deque([(search_path, line) for line in code.splitlines()])
         while stack:
             search_path, line = stack.popleft()
             if line.startswith("#include"):
@@ -377,7 +376,7 @@ class SequencerProgram:
         grammar = lark.Lark.open_from_package(
             "whatrecord",
             "snl.lark",
-            search_paths=("grammar", ),
+            search_paths=("grammar",),
             parser="earley",
             lexer_callbacks={"COMMENT": comments.append},
             propagate_positions=True,
@@ -425,7 +424,9 @@ class SequencerProgram:
 @lark.visitors.v_args(inline=True)
 class _ProgramTransformer(lark.visitors.Transformer):
     def __init__(self, cls, fn, visit_tokens=False):
-        super().__init__(visit_tokens=visit_tokens, )
+        super().__init__(
+            visit_tokens=visit_tokens,
+        )
         self.fn = str(fn)
         self.cls = cls
 
@@ -532,7 +533,9 @@ class _ProgramTransformer(lark.visitors.Transformer):
             queued=False,
         )
 
-    def syncq_flagged(self, syncq_token, variable, subscript, _, event_flag, syncq_size, __):
+    def syncq_flagged(
+        self, syncq_token, variable, subscript, _, event_flag, syncq_size, __
+    ):
         """
         SYNCQ variable opt_subscript to event_flag syncq_size SEMICOLON
         """
@@ -655,9 +658,7 @@ class _ProgramTransformer(lark.visitors.Transformer):
         type_expr
         """
         return ParameterDeclarator(
-            context=type_.context,
-            type=type_,
-            declarator=declarator
+            context=type_.context, type=type_, declarator=declarator
         )
 
     variables = transformer.tuple_args
@@ -712,7 +713,7 @@ class _ProgramTransformer(lark.visitors.Transformer):
     def abs_decl_subscript(self, *args):
         # TODO I think these may be wrong
         if len(args) == 1:
-            subscript, = args
+            (subscript,) = args
             return AbstractDeclarator(
                 context=context_from_token(self.fn, subscript),
                 subscript=str(subscript),
@@ -820,7 +821,9 @@ class _ProgramTransformer(lark.visitors.Transformer):
             target_state=str(state),
         )
 
-    def transition_exit(self, when: lark.Token, _, condition: Expression, __, block: Block, ___):
+    def transition_exit(
+        self, when: lark.Token, _, condition: Expression, __, block: Block, ___
+    ):
         """
         WHEN LPAREN condition RPAREN block EXIT
         """
@@ -951,7 +954,9 @@ class _ProgramTransformer(lark.visitors.Transformer):
             operator=str(operator),
         )
 
-    def binary_operator_expr(self, lhand: Expression, operator: lark.Token, rhand: Expression):
+    def binary_operator_expr(
+        self, lhand: Expression, operator: lark.Token, rhand: Expression
+    ):
         return BinaryOperatorExpression(
             context=context_from_token(self.fn, operator),
             left=lhand,

--- a/whatrecord/snl.py
+++ b/whatrecord/snl.py
@@ -4,23 +4,314 @@ import collections
 import pathlib
 import shlex
 from dataclasses import dataclass
-from typing import Optional
+from typing import List, Optional, Union
 
 import lark
 
-from .common import AnyPath
+from . import transformer
+from .common import AnyPath, FullLoadContext
+from .transformer import context_from_token
 
-# from . import transformer
-# from .common import (AnyPath, FullLoadContext, ShellStateHandler,
-#                      StringWithContext)
-# from .db import RecordInstance
-# from .transformer import context_from_token
+
+@dataclass
+class Assignment:
+    context: FullLoadContext
+    variable: str
+    value: Optional[Union[str, List[str]]] = None
+    subscript: Optional[int] = None
+
+
+@dataclass
+class AbstractDeclarator:
+    context: FullLoadContext
+
+
+@dataclass
+class Type:
+    context: FullLoadContext
+    name: str
+    abstract: Optional[AbstractDeclarator] = None
+
+
+@dataclass
+class Monitor:
+    context: FullLoadContext
+    variable: str
+    subscript: Optional[int]
+
+
+@dataclass
+class Option:
+    context: FullLoadContext
+    name: str
+    enable: bool
+
+
+@dataclass
+class Sync:
+    context: FullLoadContext
+    variable: str
+    subscript: Optional[int]
+    queued: bool
+    event_flag: Optional[str] = None
+    queue_size: Optional[int] = None
+
+
+@dataclass
+class Declaration:
+    context: FullLoadContext
+    type: Type
+    declarators: List[Declarator]
+
+
+@dataclass
+class Variable:
+    context: FullLoadContext
+    name: str
+
+
+@dataclass
+class ForeignVariable:
+    context: FullLoadContext
+    name: str
+
+
+@dataclass
+class Declarator:
+    context: FullLoadContext
+    object: Union[Declarator, Variable]
+    params: Optional[List[Expression]] = None
+    value: Optional[Expression] = None
+    modifier: Optional[str] = None
+    subscript: Optional[int] = None
+
+
+@dataclass
+class Parameter:
+    context: FullLoadContext
+
+
+Definition = Union[
+    Assignment,
+    Monitor,
+    Sync,
+    Declaration,
+]
+
+
+@dataclass
+class State:
+    context: FullLoadContext
+    name: str
+    definitions: List[Definition]
+    transitions: List[Transition]
+    entry: Optional[Block] = None
+    exit: Optional[Block] = None
+
+
+@dataclass
+class StateSet:
+    context: FullLoadContext
+    name: str
+    definitions: List[Definition]
+    states: List[State]
+
+
+@dataclass
+class Transition:
+    context: FullLoadContext
+    block: Block
+    target_state: Optional[str] = None
+    condition: Optional[Expression] = None
+
+
+@dataclass
+class ExitTransition(Transition):
+    ...
+
+
+@dataclass
+class Block:
+    context: FullLoadContext
+    definitions: List[Definition]
+    statements: List[Statement]
+
+
+@dataclass
+class Statement:
+    context: FullLoadContext
+
+
+@dataclass
+class BreakStatement(Statement):
+    ...
+
+
+@dataclass
+class ContinueStatement(Statement):
+    ...
+
+
+@dataclass
+class ReturnStatement(Statement):
+    value: Optional[Expression] = None
+
+
+@dataclass
+class StateStatement(Statement):
+    name: str
+
+
+@dataclass
+class WhileStatement(Statement):
+    condition: Expression
+    body: Statement
+
+
+@dataclass
+class ForStatement(Statement):
+    init: Expression
+    condition: Expression
+    increment: Expression
+    statement: Statement
+
+
+@dataclass
+class ExpressionStatement(Statement):
+    expression: Expression
+
+
+@dataclass
+class IfStatement(Statement):
+    condition: Expression
+    body: Statement
+    else_body: Optional[Statement] = None
+
+
+@dataclass
+class FuncDef:
+    context: FullLoadContext
+    type: Type
+    declarator: Declarator
+    block: Block
+
+
+@dataclass
+class StructMember:
+    context: FullLoadContext
+    type: Type
+    declarator: Declarator
+
+
+@dataclass
+class CCode:
+    context: FullLoadContext
+    code: str
+
+
+@dataclass
+class StructDef:
+    context: FullLoadContext
+    name: Type
+    members: List[Union[StructMember, CCode]]
+
+
+@dataclass
+class Expression:
+    context: FullLoadContext
+
+
+@dataclass
+class InitExpression(Expression):
+    # ( type ) { exprs }
+    # LPAREN type_expr RPAREN LBRACE init_exprs RBRACE
+    # LBRACE init_exprs RBRACE
+    # expr
+    type: Type
+
+
+@dataclass
+class Literal(Expression):
+    type: str
+    value: str
+
+
+@dataclass
+class UnaryPrefixExpression(Expression):
+    operator: str
+    expression: Expression
+
+
+@dataclass
+class UnaryPostfixExpression(Expression):
+    expression: Expression
+    operator: str
+
+
+@dataclass
+class BinaryOperatorExpression(Expression):
+    left: Expression
+    operator: str
+    right: Expression
+
+
+@dataclass
+class TypeCastExpression(Expression):
+    type: Type
+    expression: Expression
+
+
+@dataclass
+class TernaryExpression(Expression):
+    condition: Expression
+    if_true: Expression
+    if_false: Expression
+
+
+@dataclass
+class MemberExpression(Expression):
+    parent: Expression
+    member: str
+    dereference: bool  # True = ->, False = .
+
+
+@dataclass
+class SizeofExpression(Expression):
+    type: Type
+
+
+@dataclass
+class ExitExpression(Expression):
+    expression: Expression
+
+
+@dataclass
+class BracketedExpression(Expression):
+    outer: Expression
+    inner: Expression
+
+
+@dataclass
+class ParenthesisExpression(Expression):
+    expression: Expression
+
+
+@dataclass
+class ExpressionWithArguments(Expression):
+    expression: Expression
+    arguments: Expression
 
 
 @dataclass
 class SequencerProgram:
     """Representation of a state notation language (snl seq) program."""
-    # variables: Dict[str, str] = field(default_factory=dict)
+    context: FullLoadContext
+    name: str
+    initial_definitions: List[Definition]
+    entry: Block
+    state_sets: List[StateSet]
+    exit: Block
+    final_definitions: List[Definition]
 
     @staticmethod
     def preprocess(code: str, search_path: Optional[AnyPath] = None) -> str:
@@ -80,6 +371,7 @@ class SequencerProgram:
             search_paths=("grammar", ),
             parser="earley",
             lexer_callbacks={"COMMENT": comments.append},
+            propagate_positions=True,
         )
 
         search_path = None
@@ -123,10 +415,561 @@ class SequencerProgram:
 @lark.visitors.v_args(inline=True)
 class _ProgramTransformer(lark.visitors.Transformer):
     def __init__(self, cls, fn, visit_tokens=False):
-        super().__init__(visit_tokens=visit_tokens)
+        super().__init__(visit_tokens=visit_tokens, )
         self.fn = str(fn)
         self.cls = cls
 
+    def program(
+        self,
+        program_token: lark.Token,
+        name: lark.Token,
+        initial_defns: List[Definition],
+        entry: Block,
+        state_sets: List[StateSet],
+        exit: Block,
+        final_defns: List[Definition],
+    ):
+        # PROGRAM NAME program_param initial_defns entry state_sets exit final_defns
+        return self.cls(
+            context=context_from_token(self.fn, program_token),
+            name=str(name),
+            initial_definitions=initial_defns,
+            entry=entry,
+            state_sets=state_sets,
+            exit=exit,
+            final_definitions=final_defns,
+        )
+
+    # @lark.visitors.v_args(tree=True)
+    # def program(self, body):
+    #     return body
+
+    def program_param(self, *args):
+        if not args:
+            return None
+        # LPAREN string RPAREN
+        return str(args[1])
+
+    initial_defns = transformer.tuple_args
+    final_defns = transformer.tuple_args
+
+    def assign(self, assign_token, variable, _):
+        # ASSIGN variable SEMICOLON
+        return Assignment(
+            context=context_from_token(self.fn, assign_token),
+            variable=str(variable),
+        )
+
+    def assign_string(self, assign_token, variable, to_, value, _):
+        # ASSIGN variable to string SEMICOLON
+        return Assignment(
+            context=context_from_token(self.fn, assign_token),
+            variable=str(variable),
+            value=str(value),
+        )
+
+    def assign_subscript_string(self, assign_token, variable, subscript, to_, value, _):
+        # ASSIGN variable subscript to string SEMICOLON
+        return Assignment(
+            context=context_from_token(self.fn, assign_token),
+            variable=str(variable),
+            value=str(value),
+            subscript=subscript,
+        )
+
+    def assign_strings(self, assign_token, variable, to_, _, strings, *__):
+        # ASSIGN variable to LBRACE strings RBRACE SEMICOLON
+        return Assignment(
+            context=context_from_token(self.fn, assign_token),
+            variable=str(variable),
+            value=strings,
+        )
+
+    strings = transformer.tuple_args
+
+    def monitor(self, monitor_token, variable, opt_subscript, _):
+        # MONITOR variable opt_subscript SEMICOLON
+        return Monitor(
+            context=context_from_token(self.fn, monitor_token),
+            variable=str(variable),
+            subscript=opt_subscript,
+        )
+
+    def sync(self, sync_token, variable, subscript, _, event_flag, __):
+        # SYNC variable opt_subscript to event_flag SEMICOLON
+        return Sync(
+            context=context_from_token(self.fn, sync_token),
+            variable=str(variable),
+            subscript=subscript,
+            event_flag=event_flag,
+            queued=False,
+        )
+
+    def syncq_flagged(self, syncq_token, variable, subscript, _, event_flag, syncq_size, __):
+        # SYNCQ variable opt_subscript to event_flag syncq_size SEMICOLON
+        return Sync(
+            context=context_from_token(self.fn, syncq_token),
+            variable=str(variable),
+            subscript=subscript,
+            event_flag=event_flag,
+            queued=True,
+            queue_size=syncq_size,
+        )
+
+    def syncq(self, syncq_token, variable, subscript, syncq_size, _):
+        # SYNCQ variable opt_subscript syncq_size SEMICOLON
+        return Sync(
+            context=context_from_token(self.fn, syncq_token),
+            variable=str(variable),
+            subscript=subscript,
+            queued=True,
+            queue_size=syncq_size,
+        )
+
+    event_flag = transformer.stringify
+    variable = transformer.pass_through
+
+    def syncq_size(self, size=None):
+        # INTCON?
+        return int(size) if size else None
+
+    def opt_subscript(self, subscript=None):
+        return subscript
+
+    def subscript(self, _, value, __):
+        # LBRACKET INTCON RBRACKET
+        return value
+
+    def declaration(self, basetype: Type, init_declarators, _):
+        # basetype init_declarators SEMICOLON
+        return Declaration(
+            context=basetype.context,
+            type=basetype,
+            declarators=init_declarators,
+        )
+
+    def foreign_declaration(self, foreign_token, variables, _):
+        # FOREIGN variables SEMICOLON
+        return [
+            ForeignVariable(
+                context=context_from_token(self.fn, variable),
+                name=str(variable),
+            )
+            for variable in variables
+        ]
+
+    init_declarators = transformer.tuple_args
+
+    def init_declarator(self, declarator: Declarator, *equal_expr):
+        if equal_expr:
+            _, value = equal_expr
+            declarator.value = value
+        return declarator
+
+    def declarator(self, variable: lark.Token):
+        return Declarator(
+            context=context_from_token(self.fn, variable),
+            object=Variable(
+                context=context_from_token(self.fn, variable),
+                name=str(variable),
+            ),
+        )
+
+    def declarator_decls(self, declarator, _, param_decls, __):
+        return Declarator(
+            context=declarator.context,
+            object=declarator,
+            params=param_decls,
+        )
+
+    def declarator_subscript(self, declarator, subscript):
+        return Declarator(
+            context=declarator.context,
+            object=declarator,
+            subscript=subscript,
+        )
+
+    def declarator_paren(self, _, declarator, __):
+        return Declarator(
+            context=declarator.context,
+            object=declarator,
+            modifier="()",
+        )
+
+    def declarator_deref(self, asterisk, declarator):
+        return Declarator(
+            context=context_from_token(self.fn, asterisk),
+            object=declarator,
+            modifier="*",
+        )
+
+    def declarator_const(self, const, declarator):
+        return Declarator(
+            context=context_from_token(self.fn, const),
+            object=declarator,
+            modifier="const",
+        )
+
+    param_decls = transformer.tuple_args
+
+    # def param_decl(self, type_, declarator=None):
+    #     # basetype declarator
+    #     # type_expr
+    # TODO not done yet
+
+    variables = transformer.tuple_args
+
+    def init_expr(self, lparen, type_expr, _, __, init_exprs, ___):
+        # LPAREN type_expr RPAREN LBRACE init_exprs RBRACE
+        # TODO wrong
+        return InitExpression(
+            context=context_from_token(self.fn, lparen),
+            type=type_expr,
+            init_exprs=init_exprs,
+        )
+
+    init_exprs = transformer.tuple_args
+
+    def basetype(self, *type_info):
+        return Type(
+            context=context_from_token(self.fn, type_info[0]),
+            name=" ".join(type_info),
+        )
+
+    def type_expr(self, basetype, abs_decl=None):
+        basetype.abstract = abs_decl
+        return basetype
+
+    def abs_decl(self, *args):
+        # LPAREN abs_decl RPAREN
+        # ASTERISK
+        # ASTERISK abs_decl
+        # CONST
+        # CONST abs_decl
+        # subscript
+        # abs_decl subscript
+        # LPAREN param_decls RPAREN
+        # abs_decl LPAREN param_decls RPAREN
+        # TODO not done yet
+        return args  # TODO
+
+    def option(self, option_token, value, name, _):
+        # OPTION option_value NAME SEMICOLON
+        return Option(
+            context=context_from_token(self.fn, option_token),
+            name=name,
+            enable=(value == "+"),  # "+" or "-"
+        )
+
+    option_value = transformer.stringify
+    state_sets = transformer.tuple_args
+
+    def state_set(self, state_set_token, name, _, defns, states, __):
+        # STATE_SET NAME LBRACE ss_defns states RBRACE
+        return StateSet(
+            context=context_from_token(self.fn, state_set_token),
+            name=name,
+            definitions=defns,
+            states=states,
+        )
+
+    ss_defns = transformer.tuple_args
+
+    states = transformer.tuple_args
+
+    def state(
+        self,
+        state_token,
+        name: lark.Token,
+        _,
+        definitions: List[Definition],
+        entry: Block,
+        transitions: List[Transition],
+        exit: Block,
+        __,
+    ):
+        # STATE NAME LBRACE state_defns entry? transitions exit? RBRACE
+        return State(
+            context=context_from_token(self.fn, state_token),
+            name=str(name),
+            definitions=definitions,
+            entry=entry,
+            transitions=transitions,
+            exit=exit,
+        )
+
+    state_defns = transformer.tuple_args
+
+    def entry(self, *args):
+        if args:
+            _, block = args
+            return block
+        return None
+
+    exit = entry
+    transitions = transformer.tuple_args
+
+    def transition(
+        self,
+        when: lark.Token,
+        _,
+        condition: Expression,
+        __,
+        block: Block,
+        ___,
+        state: lark.Token,
+    ):
+        # WHEN LPAREN condition RPAREN block STATE NAME
+        return Transition(
+            context=context_from_token(self.fn, when),
+            condition=condition,
+            block=block,
+            target_state=str(state),
+        )
+
+    def transition_exit(self, when: lark.Token, _, condition: Expression, __, block: Block, ___):
+        # WHEN LPAREN condition RPAREN block EXIT
+        return ExitTransition(
+            context=context_from_token(self.fn, when),
+            condition=condition,
+            block=block,
+        )
+
+    condition = transformer.pass_through
+
+    def block(self, lbrace: lark.Token, definitions, statements, _):
+        # LBRACE block_defns statements RBRACE
+        return Block(
+            context=context_from_token(self.fn, lbrace),
+            definitions=definitions,
+            statements=statements,
+        )
+
+    block_defns = transformer.tuple_args
+    statements = transformer.tuple_args
+    statement = transformer.pass_through
+
+    def break_statement(self, break_token: lark.Token, _):
+        return BreakStatement(
+            context=context_from_token(self.fn, break_token),
+        )
+
+    def continue_statement(self, continue_token: lark.Token, _):
+        return ContinueStatement(
+            context=context_from_token(self.fn, continue_token),
+        )
+
+    def return_statement(self, return_token: lark.Token, value: Expression, _):
+        return ReturnStatement(
+            context=context_from_token(self.fn, return_token),
+            value=value,
+        )
+
+    def state_statement(self, state_token: lark.Token, name: lark.Token, _):
+        return StateStatement(
+            context=context_from_token(self.fn, state_token),
+            name=str(name),
+        )
+
+    def while_statement(
+        self,
+        while_token: lark.Token,
+        _,
+        condition: Expression,
+        __,
+        statement: Statement,
+    ):
+        return WhileStatement(
+            context=context_from_token(self.fn, while_token),
+            condition=condition,
+            body=statement,
+        )
+
+    def expr_statement(self, expression: Expression, semicolon: lark.Token):
+        return ExpressionStatement(
+            context=context_from_token(self.fn, semicolon),
+            expression=expression,
+        )
+
+    statement = transformer.pass_through
+
+    def if_statement(
+        self,
+        if_token: lark.Token,
+        _,
+        condition: Expression,
+        __,
+        body: Expression,
+        *else_clause
+    ):
+        if else_clause:
+            else_token, else_body = else_clause
+        else:
+            else_body = None
+
+        # IF LPAREN comma_expr RPAREN statement (ELSE statement)?
+        return IfStatement(
+            context=context_from_token(self.fn, if_token),
+            condition=condition,
+            body=body,
+            else_body=else_body,
+        )
+
+    def for_statement(
+        self,
+        for_token: lark.Token,
+        _,
+        init: Expression,
+        __,
+        condition: Expression,
+        ___,
+        increment: Expression,
+        ____,
+        statement: Statement,
+    ):
+        # FOR LPAREN opt_expr SEMICOLON opt_expr SEMICOLON opt_expr RPAREN statement
+        return ForStatement(
+            context=context_from_token(self.fn, for_token),
+            init=init,
+            condition=condition,
+            increment=increment,
+            statement=statement,
+        )
+
+    def unary_prefix_expr(self, operator: lark.Token, expr: Expression):
+        return UnaryPrefixExpression(
+            context=context_from_token(self.fn, operator),
+            operator=str(operator),
+            expression=expr,
+        )
+
+    def unary_postfix_expr(self, expr: Expression, operator: lark.Token):
+        return UnaryPostfixExpression(
+            context=context_from_token(self.fn, operator),
+            expression=expr,
+            operator=str(operator),
+        )
+
+    def binary_operator_expr(self, lhand: Expression, operator: lark.Token, rhand: Expression):
+        return BinaryOperatorExpression(
+            context=context_from_token(self.fn, operator),
+            left=lhand,
+            operator=str(operator),
+            right=rhand,
+        )
+
+    def type_cast_expr(self, lparen, type_expr, _, expr):
+        return TypeCastExpression(
+            context=context_from_token(self.fn, lparen),
+            type=type_expr,
+            expression=expr,
+        )
+
+    def sizeof(self, sizeof_token: lark.Token, _, type_expr: Type, __):
+        return SizeofExpression(
+            context=context_from_token(self.fn, sizeof_token),
+            type=type_expr,
+        )
+
+    def exit_expr(self, exit_token: lark.Token, _, expr: Expression, __):
+        return ExitExpression(
+            context=context_from_token(self.fn, exit_token),
+            expression=expr,
+        )
+
+    def expr_with_args(self, expression: Expression, tok: lark.Token, arguments: Expression, __):
+        return ExpressionWithArguments(
+            context=context_from_token(self.fn, tok),
+            expression=expression,
+            arguments=arguments,
+        )
+
+    def bracket_expr(self, outer: Expression, tok: lark.Token, inner: Expression, __):
+        return BracketedExpression(
+            context=context_from_token(self.fn, tok),
+            outer=outer,
+            inner=inner,
+        )
+
+    def parenthesized_expr(self, lparen: lark.Token, expression: Expression, _):
+        return ParenthesisExpression(
+            context=context_from_token(self.fn, lparen),
+            expression=expression,
+        )
+
+    def ternary_expr(self, condition, question, if_true, _, if_false):
+        return TernaryExpression(
+            context=context_from_token(self.fn, question),
+            condition=condition,
+            if_true=if_true,
+            if_false=if_false,
+        )
+
+    def member_expr(self, expr: Expression, operator: lark.Token, member: lark.Token):
+        return MemberExpression(
+            context=context_from_token(self.fn, operator),
+            parent=expr,
+            member=str(member),
+            dereference=operator == "->",
+        )
+
     @lark.visitors.v_args(tree=True)
-    def program(self, body):
-        return body
+    def literal_expr(self, item):
+        child = item.children[0]
+        if isinstance(child, lark.Token):
+            value = str(child)
+        else:
+            value = "".join(child.children)
+        return Literal(
+            context=context_from_token(self.fn, item),
+            type=item.data,
+            # [Tree('variable', [Token('NAME', 'seq_test_init')])]
+            value=value,
+        )
+
+    comma_expr = transformer.tuple_args
+    opt_expr = transformer.pass_through
+
+    args = transformer.tuple_args
+
+    string = transformer.pass_through
+    member = transformer.pass_through
+
+    def funcdef(self, basetype: Type, declarator: Declarator, block: Block):
+        # basetype declarator block
+        return FuncDef(
+            context=basetype.context,
+            type=basetype,
+            declarator=declarator,
+            block=block,
+        )
+
+    def structdef(self, struct_token, name, members, _):
+        # STRUCT NAME members SEMICOLON
+        return StructDef(
+            context=context_from_token(self.fn, struct_token),
+            name=name,
+            members=members,
+        )
+
+    def members(self, _, decls, __):
+        # LBRACE member_decls RBRACE
+        return decls
+
+    member_decls = transformer.tuple_args
+
+    def member_decl(self, type: Type, declarator: Declarator, _):
+        # basetype declarator SEMICOLON
+        return StructMember(
+            context=type.context,
+            type=type,
+            declarator=declarator,
+        )
+
+    member_decl_ccode = transformer.pass_through
+
+    def c_code(self, c_code):
+        return CCode(
+            context=context_from_token(self.fn, c_code),
+            code=str(c_code),
+        )

--- a/whatrecord/snl.py
+++ b/whatrecord/snl.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import collections
 import pathlib
 import shlex
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional, Tuple, Union
 
 import lark
@@ -36,7 +36,7 @@ class Assignment(Definition):
 @dataclass
 class AbstractDeclarator:
     context: FullLoadContext
-    params: Tuple[ParameterDeclarator, ...]
+    params: Tuple[ParameterDeclarator, ...] = field(default_factory=tuple)
     modifier: Optional[str] = None
     subscript: Optional[int] = None
 
@@ -71,13 +71,13 @@ class Sync(Definition):
 
 @dataclass
 class Declaration(Definition):
-    type: Optional[Type]
-    declarators: Optional[Tuple[Declarator, ...]]
+    type: Optional[Type] = None
+    declarators: Optional[Tuple[Declarator, ...]] = field(default_factory=tuple)
 
 
 @dataclass
 class ForeignDeclaration(Declaration):
-    names: Tuple[str, ...]
+    names: Tuple[str, ...] = field(default_factory=tuple)
 
 
 @dataclass
@@ -106,8 +106,8 @@ class ParameterDeclarator:
 class State:
     context: FullLoadContext
     name: str
-    definitions: Tuple[Definition, ...]
-    transitions: Tuple[Transition, ...]
+    definitions: Tuple[Definition, ...] = field(default_factory=tuple)
+    transitions: Tuple[Transition, ...] = field(default_factory=tuple)
     entry: Optional[Block] = None
     exit: Optional[Block] = None
 
@@ -116,8 +116,8 @@ class State:
 class StateSet:
     context: FullLoadContext
     name: str
-    definitions: Tuple[Definition, ...]
-    states: Tuple[State, ...]
+    definitions: Tuple[Definition, ...] = field(default_factory=tuple)
+    states: Tuple[State, ...] = field(default_factory=tuple)
 
 
 @dataclass
@@ -136,8 +136,8 @@ class ExitTransition(Transition):
 @dataclass
 class Block:
     context: FullLoadContext
-    definitions: Tuple[Definition, ...]
-    statements: Tuple[Statement, ...]
+    definitions: Tuple[Definition, ...] = field(default_factory=tuple)
+    statements: Tuple[Statement, ...] = field(default_factory=tuple)
 
 
 @dataclass
@@ -213,7 +213,7 @@ class CCode(Definition):
 @dataclass
 class StructDef(Definition):
     name: str
-    members: Tuple[Union[StructMember, CCode], ...]
+    members: Tuple[Union[StructMember, CCode], ...] = field(default_factory=tuple)
 
 
 @dataclass
@@ -228,7 +228,7 @@ class InitExpression(Expression):
     # expr
     # TODO: may be improved?
     context: FullLoadContext
-    expressions: Tuple[Union[InitExpression, Expression], ...]
+    expressions: Tuple[Union[InitExpression, Expression], ...] = field(default_factory=tuple)
     type: Optional[Type] = None
 
 
@@ -301,7 +301,7 @@ class ParenthesisExpression(Expression):
 @dataclass
 class ExpressionWithArguments(Expression):
     expression: Expression
-    arguments: Tuple[Expression, ...]
+    arguments: Tuple[Expression, ...] = field(default_factory=tuple)
 
 
 @dataclass
@@ -310,11 +310,11 @@ class SequencerProgram:
     context: FullLoadContext
     name: str
     params: Optional[str]
-    initial_definitions: Tuple[Definition, ...]
-    entry: Optional[Block]
-    state_sets: Tuple[StateSet, ...]
-    exit: Optional[Block]
-    final_definitions: Tuple[Definition, ...]
+    initial_definitions: Tuple[Definition, ...] = field(default_factory=tuple)
+    entry: Optional[Block] = None
+    state_sets: Tuple[StateSet, ...] = field(default_factory=tuple)
+    exit: Optional[Block] = None
+    final_definitions: Tuple[Definition, ...] = field(default_factory=tuple)
 
     @staticmethod
     def preprocess(code: str, search_path: Optional[AnyPath] = None) -> str:
@@ -921,7 +921,13 @@ class _ProgramTransformer(lark.visitors.Transformer):
             expression=expr,
         )
 
-    def expr_with_args(self, expression: Expression, tok: lark.Token, arguments: Expression, __):
+    def expr_with_args(
+        self,
+        expression: Expression,
+        tok: lark.Token,
+        arguments: Tuple[Expression, ...],
+        _,
+    ):
         return ExpressionWithArguments(
             context=context_from_token(self.fn, tok),
             expression=expression,

--- a/whatrecord/snl.py
+++ b/whatrecord/snl.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import pathlib
+from dataclasses import dataclass, field
+from typing import Any, ClassVar, Dict, List, Optional
+
+import lark
+
+from . import transformer
+from .common import (AnyPath, FullLoadContext, ShellStateHandler,
+                     StringWithContext)
+from .db import PVAFieldReference, RecordInstance
+from .iocsh import split_words
+from .transformer import context_from_token
+
+
+@dataclass
+class SequencerProgram:
+    """Representation of a state notation language (snl seq) program."""
+    # variables: Dict[str, str] = field(default_factory=dict)
+
+    @classmethod
+    def from_string(
+        cls, contents: str, filename=None,
+    ) -> SequencerProgram:
+        """Load a state notation language file given its string contents."""
+        comments = []
+        grammar = lark.Lark.open_from_package(
+            "whatrecord",
+            "snl.lark",
+            search_paths=("grammar", ),
+            parser="lalr",
+            lexer_callbacks={"COMMENT": comments.append},
+        )
+
+        proto = _ProgramTransformer(cls, filename).transform(
+            grammar.parse(contents)
+        )
+        proto.comments = comments
+        return proto
+
+    @classmethod
+    def from_file_obj(cls, fp, filename=None) -> SequencerProgram:
+        """Load a state notation language program given a file object."""
+        return cls.from_string(
+            fp.read(),
+            filename=getattr(fp, "name", filename),
+        )
+
+    @classmethod
+    def from_file(cls, fn) -> SequencerProgram:
+        """
+        Load a state notation language file.
+
+        Parameters
+        ----------
+        filename : pathlib.Path or str
+            The filename.
+
+        Returns
+        -------
+        program : SequencerProgram
+            The parsed program.
+        """
+        with open(fn, "rt") as fp:
+            return cls.from_string(fp.read(), filename=fn)
+
+
+@lark.visitors.v_args(inline=True)
+class _ProgramTransformer(lark.visitors.Transformer):
+    def __init__(self, cls, fn, visit_tokens=False):
+        super().__init__(visit_tokens=visit_tokens)
+        self.fn = str(fn)
+        self.cls = cls
+
+    @lark.visitors.v_args(tree=True)
+    def program(self, body):
+        return body

--- a/whatrecord/tests/iocs/ioc_sequencer/LICENSE
+++ b/whatrecord/tests/iocs/ioc_sequencer/LICENSE
@@ -1,0 +1,78 @@
+===============================================================================
+Files in this directory as part of the whatrecord test suite are from the EPICS
+sequencer repository and are subject to their original licenses.  That license
+is reproduced below for reference
+===============================================================================
+
+Copyright (c) 1989-1994 The Regents of the University of California
+                        and the University of Chicago Board of Governors.
+                        Los Alamos National Laboratory
+Copyright (c) 2010-2015 Helmholtz-Zentrum Berlin f. Materialien
+                        und Energie GmbH, Germany (HZB)
+
+All rights reserved.
+
+The EPICS Sequencer is distributed subject to the following license conditions:
+
+ SOFTWARE LICENSE AGREEMENT
+ Software: EPICS Sequencer
+
+ 1. The "Software", below, refers to EPICS Sequencer (in either source code, or
+    binary form and accompanying documentation). Each licensee is
+    addressed as "you" or "Licensee."
+
+ 2. The copyright holders shown above and their third-party licensors
+    hereby grant Licensee a royalty-free nonexclusive license, subject to
+    the limitations stated herein and U.S. Government license rights.
+
+ 3. You may modify and make a copy or copies of the Software for use
+    within your organization, if you meet the following conditions:
+
+      a. Copies in source code must include the copyright notice and this
+         Software License Agreement.
+      b. Copies in binary form must include the copyright notice and this
+         Software License Agreement in the documentation and/or other
+         materials provided with the copy.
+
+ 4. You may modify a copy or copies of the Software or any portion of it,
+    thus forming a work based on the Software, and distribute copies of
+    such work outside your organization, if you meet all of the following
+    conditions:
+
+      a. Copies in source code must include the copyright notice and this
+         Software License Agreement;
+      b. Copies in binary form must include the copyright notice and this
+         Software License Agreement in the documentation and/or other
+         materials provided with the copy;
+      c. Modified copies and works based on the Software must carry
+         prominent notices stating that you changed specified portions of
+         the Software.
+
+ 5. Portions of the Software resulted from work developed under a U.S.
+    Government contract and are subject to the following license: the
+    Government is granted for itself and others acting on its behalf a
+    paid-up, nonexclusive, irrevocable worldwide license in this computer
+    software to reproduce, prepare derivative works, and perform publicly
+    and display publicly.
+
+ 6. WARRANTY DISCLAIMER. THE SOFTWARE IS SUPPLIED "AS IS" WITHOUT WARRANTY
+    OF ANY KIND. THE COPYRIGHT HOLDERS, THEIR THIRD PARTY LICENSORS, THE
+    UNITED STATES, THE UNITED STATES DEPARTMENT OF ENERGY, AND THEIR
+    EMPLOYEES: (1) DISCLAIM ANY WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+    BUT NOT LIMITED TO ANY IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE, TITLE OR NON-INFRINGEMENT, (2) DO NOT ASSUME
+    ANY LEGAL LIABILITY OR RESPONSIBILITY FOR THE ACCURACY, COMPLETENESS,
+    OR USEFULNESS OF THE SOFTWARE, (3) DO NOT REPRESENT THAT USE OF THE
+    SOFTWARE WOULD NOT INFRINGE PRIVATELY OWNED RIGHTS, (4) DO NOT WARRANT
+    THAT THE SOFTWARE WILL FUNCTION UNINTERRUPTED, THAT IT IS ERROR-FREE
+    OR THAT ANY ERRORS WILL BE CORRECTED.
+
+ 7. LIMITATION OF LIABILITY. IN NO EVENT WILL THE COPYRIGHT HOLDERS, THEIR
+    THIRD PARTY LICENSORS, THE UNITED STATES, THE UNITED STATES DEPARTMENT
+    OF ENERGY, OR THEIR EMPLOYEES: BE LIABLE FOR ANY INDIRECT, INCIDENTAL,
+    CONSEQUENTIAL, SPECIAL OR PUNITIVE DAMAGES OF ANY KIND OR NATURE,
+    INCLUDING BUT NOT LIMITED TO LOSS OF PROFITS OR LOSS OF DATA, FOR ANY
+    REASON WHATSOEVER, WHETHER SUCH LIABILITY IS ASSERTED ON THE BASIS OF
+    CONTRACT, TORT (INCLUDING NEGLIGENCE OR STRICT LIABILITY), OR
+    OTHERWISE, EVEN IF ANY OF SAID PARTIES HAS BEEN WARNED OF THE
+    POSSIBILITY OF SUCH LOSS OR DAMAGES.

--- a/whatrecord/tests/iocs/ioc_sequencer/sncExEntry.st
+++ b/whatrecord/tests/iocs/ioc_sequencer/sncExEntry.st
@@ -1,0 +1,42 @@
+/*************************************************************************\
+This file is distributed subject to a Software License Agreement found
+in the file LICENSE that is included with this distribution.
+\*************************************************************************/
+program snctest
+float v;
+assign v to "{user}:xxxExample";
+monitor v;
+
+ss ss1
+{
+	state low
+	{
+	    entry 
+	    { 
+		printf("Will do this on entry");
+		printf("Another thing to do on entry");
+	    }
+	    when(v>5.0)
+	    {
+		printf("now changing to high\n");
+	    } state high
+	    when(delay(.1)) 
+	    {
+	    } state low
+	    exit 
+	    { 
+		printf("Something to do on exit");
+	    }
+
+	}
+	state high
+	{
+	    when(v<=5.0)
+	    {
+		printf("changing to low\n");
+	    } state low
+	    when(delay(.1))
+	    {
+	    } state high
+	}
+}

--- a/whatrecord/tests/iocs/ioc_sequencer/sncExOpt.st
+++ b/whatrecord/tests/iocs/ioc_sequencer/sncExOpt.st
@@ -1,0 +1,43 @@
+/*************************************************************************\
+This file is distributed subject to a Software License Agreement found
+in the file LICENSE that is included with this distribution.
+\*************************************************************************/
+program snctest
+float v;
+assign v to "{user}:xxxExample";
+monitor v;
+
+ss ss1
+{
+	state low
+	{
+            option +t; /* The default is +t, so thsi has no effect */
+	    entry 
+	    { 
+		printf("Will do this on entry");
+		printf("Another thing to do on entry");
+	    }
+	    when(v>5.0)
+	    {
+		printf("now changing to high\n");
+	    } state high
+	    when(delay(.1)) 
+	    {
+		/* Pause of .1 on every iteration */
+	    } state low
+	}
+	state high
+	{
+            option -t;
+	    when(v<=5.0)
+	    {
+		printf("changing to low\n");
+	    } state low
+	    when(delay(.1))
+	    {
+		/* After 1st pause of .1 sec, state high will enter a tight loop
+                   entering this condition on each iteration until v is 
+                   set to less <= 5.0 */
+	    } state high
+	}
+}

--- a/whatrecord/tests/iocs/ioc_sequencer/sncExample.st
+++ b/whatrecord/tests/iocs/ioc_sequencer/sncExample.st
@@ -1,0 +1,33 @@
+/*************************************************************************\
+This file is distributed subject to a Software License Agreement found
+in the file LICENSE that is included with this distribution.
+\*************************************************************************/
+program snctest
+option +r;
+float v;
+assign v to "{user}:xxxExample";
+monitor v;
+
+ss ss1
+{
+	state low
+	{
+	    when(v>5.0)
+	    {
+		printf("now changing to high\n");
+	    } state high
+	    when(delay(.1)) 
+	    {
+	    } state low
+	}
+	state high
+	{
+	    when(v<=5.0)
+	    {
+		printf("changing to low\n");
+	    } state low
+	    when(delay(.1))
+	    {
+	    } state high
+	}
+}

--- a/whatrecord/tests/test_serialization.py
+++ b/whatrecord/tests/test_serialization.py
@@ -14,7 +14,7 @@ import apischema
 import pytest
 
 from .. import (access_security, asyn, autosave, cache, common, ioc_finder,
-                motor, shell)
+                motor, shell, snl)
 from ..common import FullLoadContext, LoadContext
 
 MODULE_PATH = Path(__file__).parent
@@ -108,9 +108,12 @@ init_args_by_type = {
     str: "testing",
     typing.Any: 123,
     typing.Tuple[str, str]: ("a", "b"),
+    Optional[int]: 11,
     Optional[common.RecordDefinitionAndInstance]: None,
     Optional[common.RecordInstance]: None,
     Optional[common.RecordType]: None,
+    Union[snl.Declarator, snl.Variable]: snl.Variable(context=[], name="test"),
+    snl.OptionalExpression: None,
 }
 
 

--- a/whatrecord/tests/test_snl.py
+++ b/whatrecord/tests/test_snl.py
@@ -1,0 +1,36 @@
+import pathlib
+import pprint
+
+import apischema
+import pytest
+
+from ..streamdevice import StreamProtocol
+from . import conftest
+
+PROTOCOL_FILES = list((conftest.MODULE_PATH / "iocs").glob("**/*.proto"))
+
+additional_files = conftest.MODULE_PATH / "streamdevice_filenames.txt"
+if additional_files.exists():
+    for additional in open(additional_files, "rt").read().splitlines():
+        PROTOCOL_FILES.append(pathlib.Path(additional))
+
+
+protocol_files = pytest.mark.parametrize(
+    "protocol_file",
+    [
+        pytest.param(
+            protocol_file,
+            id="/".join(protocol_file.parts[-2:])
+        )
+        for protocol_file in PROTOCOL_FILES
+    ]
+)
+
+
+@protocol_files
+def test_parse(protocol_file):
+    proto = StreamProtocol.from_file(protocol_file)
+
+    serialized = apischema.serialize(proto)
+    pprint.pprint(serialized)
+    apischema.deserialize(StreamProtocol, serialized)

--- a/whatrecord/tests/test_snl.py
+++ b/whatrecord/tests/test_snl.py
@@ -1,14 +1,12 @@
 import pathlib
-# import apischema
+import pprint
 import textwrap
 
+import apischema
 import pytest
 
 from ..snl import SequencerProgram
 from . import conftest
-
-# import pprint
-
 
 SNL_FILES = list((conftest.MODULE_PATH / "iocs").glob("**/*.st"))
 
@@ -53,8 +51,8 @@ def test_parse(program_filename):
     # print(ctx.render_object(program, "console"))
     print(program)
 
-    # serialized = apischema.serialize(program)
-    # pprint.pprint(serialized)
+    serialized = apischema.serialize(program)
+    pprint.pprint(serialized)
     # apischema.deserialize(SequencerProgram, serialized)
 
 

--- a/whatrecord/tests/test_snl.py
+++ b/whatrecord/tests/test_snl.py
@@ -1,5 +1,5 @@
 import pathlib
-import pprint
+# import pprint
 import textwrap
 
 import apischema
@@ -52,8 +52,8 @@ def test_parse(program_filename):
     print(program)
 
     serialized = apischema.serialize(program)
-    pprint.pprint(serialized)
-    # apischema.deserialize(SequencerProgram, serialized)
+    # pprint.pprint(serialized)
+    apischema.deserialize(SequencerProgram, serialized)
 
 
 @pytest.mark.parametrize(

--- a/whatrecord/tests/test_snl.py
+++ b/whatrecord/tests/test_snl.py
@@ -1,36 +1,39 @@
 import pathlib
-import pprint
 
-import apischema
+# import apischema
 import pytest
 
-from ..streamdevice import StreamProtocol
+from ..snl import SequencerProgram
 from . import conftest
 
-PROTOCOL_FILES = list((conftest.MODULE_PATH / "iocs").glob("**/*.proto"))
+# import pprint
 
-additional_files = conftest.MODULE_PATH / "streamdevice_filenames.txt"
+
+SNL_FILES = list((conftest.MODULE_PATH / "iocs").glob("**/*.st"))
+
+additional_files = conftest.MODULE_PATH / "sequencer_filenames.txt"
 if additional_files.exists():
     for additional in open(additional_files, "rt").read().splitlines():
-        PROTOCOL_FILES.append(pathlib.Path(additional))
+        SNL_FILES.append(pathlib.Path(additional))
 
 
-protocol_files = pytest.mark.parametrize(
-    "protocol_file",
+snl_filenames = pytest.mark.parametrize(
+    "program_filename",
     [
         pytest.param(
-            protocol_file,
-            id="/".join(protocol_file.parts[-2:])
+            program_filename,
+            id="/".join(program_filename.parts[-2:])
         )
-        for protocol_file in PROTOCOL_FILES
+        for program_filename in SNL_FILES
     ]
 )
 
 
-@protocol_files
-def test_parse(protocol_file):
-    proto = StreamProtocol.from_file(protocol_file)
+@snl_filenames
+def test_parse(program_filename):
+    program = SequencerProgram.from_file(program_filename)
+    print(program.pretty())
 
-    serialized = apischema.serialize(proto)
-    pprint.pprint(serialized)
-    apischema.deserialize(StreamProtocol, serialized)
+    # serialized = apischema.serialize(program)
+    # pprint.pprint(serialized)
+    # apischema.deserialize(SequencerProgram, serialized)

--- a/whatrecord/tests/test_snl.py
+++ b/whatrecord/tests/test_snl.py
@@ -1,6 +1,7 @@
 import pathlib
-
 # import apischema
+import textwrap
+
 import pytest
 
 from ..snl import SequencerProgram
@@ -37,3 +38,88 @@ def test_parse(program_filename):
     # serialized = apischema.serialize(program)
     # pprint.pprint(serialized)
     # apischema.deserialize(SequencerProgram, serialized)
+
+
+@pytest.mark.parametrize(
+    "source, partial_error",
+    [
+        # No clue why this is failing...
+        pytest.param(
+            """\
+            program name
+
+
+            %{
+                code1
+            }%
+
+            entry {
+                seq_test_init(20);
+            }
+
+            ss myss {
+                state doit {
+                    when (delay(0.1)) {
+                    } state doit
+                    when (i_saved == 10) {
+                    } exit
+                }
+            }
+
+            exit {
+            }
+
+            %{
+                adding code2 -> unexpected eof
+            }%
+            """,
+            "Unexpected end-of-input",
+            id="two_ccode"
+        ),
+        pytest.param(
+            """\
+            program name
+            #define VALUE 5
+
+            double a[VALUE];
+
+            ss simple {
+                state simple {
+                    when () {} exit
+                }
+            }
+            """,
+            "No terminal matches 'V' in the current parser context",
+            id="preprocessor_define"
+        ),
+        pytest.param(
+            """\
+            program name
+            #define DEFINED 1
+
+            #if DEFINED
+            #else
+            !!! invalid syntax
+            #endif
+            double a[VALUE];
+
+            ss simple {
+                state simple {
+                    when () {} exit
+                }
+            }
+            """,
+            "No terminal matches '!' in the current parser context",
+            id="preprocessor_define"
+        ),
+    ]
+)
+@pytest.mark.xfail(strict=True, reason="grammar bug?")
+def test_tofix(source, partial_error):
+    source = textwrap.dedent(source)
+    try:
+        SequencerProgram.from_string(source)
+    except Exception as ex:
+        if partial_error in str(ex):
+            raise
+        print(ex)

--- a/whatrecord/tests/test_snl.py
+++ b/whatrecord/tests/test_snl.py
@@ -47,7 +47,11 @@ def test_parse(program_filename):
         )
 
     program = SequencerProgram.from_file(program_filename)
-    print(program.pretty())
+
+    # from ..format import FormatContext
+    # ctx = FormatContext()
+    # print(ctx.render_object(program, "console"))
+    print(program)
 
     # serialized = apischema.serialize(program)
     # pprint.pprint(serialized)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
* Adds grammar and Python classes for the EPICS sequencer's state notation language (snl, extension `.st`)
* Adds hook for `whatrecord parse` to support `.st` files

## Motivation and Context
Closes #90 (I'll get around to the state transition diagrams one day)

## How Has This Been Tested?
* Test suite with example `.st` files and apischema serialization/deserialization
* Plus around 90 additional `.st` files not included in the repository
* All but those requiring a C preprocessor to take care of `#define` and such will work
* Added some tests which show how the lack of a proper preprocessor can screw things up
