### PR TITLE
BLD: use pyproject.toml to add build requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ env:
     - CONDA_REQUIREMENTS="dev-requirements.txt"
     - CONDA_EXTRAS=""
     - CONDA_ENV_NAME="testenv"
-    - BUILD_REQUIREMENTS="epicscorelibs cython"
 
 addons:
   apt:
@@ -45,8 +44,6 @@ jobs:
       python: 3.8
       install:
         - python -m pip install --upgrade pip
-        # Build requirements, for now:
-        - python -m pip install ${BUILD_REQUIREMENTS}
         - python -m pip install .
         - python -m pip install --requirement dev-requirements.txt
       script:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,10 +1,11 @@
 include LICENSE.md
 include README.rst
 include dev-requirements.txt
+include pyproject.toml
 include requirements.txt
 include versioneer.py
 
-recursive-include whatrecord/_whatrecord *.pyx
+recursive-include src/_whatrecord *.pyx
 recursive-include whatrecord/grammar *.lark
 recursive-include whatrecord/tests *.db *.cmd *.dbd *.proto *.pvlist *.acf t1-*.txt
 recursive-include whatrecord/tests *.substitutions *.substitutions.expanded

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+    "cython",
+    "epicscorelibs",
+    "setuptools",
+    "setuptools_dso",
+    "wheel",
+]


### PR DESCRIPTION
Closes #98 (or if it doesn't, I'll reopen it)

This appears to work locally in a clean environment.

I don't like using separate build config files, so this will take some more reworking down the line. Consider it a hotfix for today's environment build.