### PR TITLE
FIX: malformed links can have multiple dots

### DIFF
--- a/whatrecord/graph.py
+++ b/whatrecord/graph.py
@@ -230,7 +230,7 @@ def build_database_relations(
             # field1.context = rec1.context[:1] + field1.context
 
             if "." in link:
-                link, field2 = link.split(".")
+                link, field2 = link.split(".", 1)
             elif field1.name == "FLNK":
                 field2 = "PROC"
             else:


### PR DESCRIPTION
I ran into this invalid one today:

`'$@lakeshore331.proto.db'` which caused

```
  File "whatrecord/whatrecord/graph.py", line 233, in build_database_relations
    link, field2 = link.split(".")
ValueError: too many values to unpack (expected 2)
```

This will still show an invalid record and field, but I think this is preferable to throwing it away.