### PR TITLE
BLD: update pinning of apischema + Python

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -12,19 +12,19 @@ build:
 
 requirements:
     build:
-      - python >=3.7
+      - python >=3.9
       - setuptools
       - epicscorelibs
       - setuptools_dso
       - cython
     run:
-      - python >=3.7
+      - python >=3.9
       - aiohttp
       - graphviz
       - python-graphviz
       - jinja2
       - lark-parser
-      - apischema
+      - apischema <0.16
 
 test:
     imports:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp
-apischema[graphql]
+apischema[graphql]<0.16
 graphviz
 jinja2
 lark-parser


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Addresses #110 
* Bumps minimum Python to 3.9+. I noticed at some point 3.7 was broken when using `Tuple[type, ...]` syntax but gave up on adhering to that. 3.7 isn't a target for us in general, but PyPy (stuck at 3.7) will no longer work. It offers significant speedups over CPython for some of the large lark grammars we have here and the corresponding apischema serialization/deserialization.

## Motivation and Context
Long-term whatrecord will need some fixing - tuple handling with apischema changed from 0.15.7 to 0.16.0 and lead to much of the test suite being broken. I'm unsure at this point how much is whatrecord using the library wrong versus potential (but unlikely) apischema bugs. 

So - pin for now.

## How Has This Been Tested?
Local testing comparing apischema versions.

## Where Has This Been Documented?
Linked issue.