### PR TITLE
ENH: add 'whatrecord graph' entrypoint with at least db/st.cmd support

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
       - graphviz
       - python-graphviz
       - jinja2
-      - lark-parser
+      - lark-parser <1.0
       - apischema <0.16
 
 test:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ aiohttp
 apischema[graphql]<0.16
 graphviz
 jinja2
-lark-parser
+lark-parser<1.0

--- a/whatrecord/access_security.py
+++ b/whatrecord/access_security.py
@@ -344,6 +344,7 @@ class AccessSecurityConfig:
             parser="lalr",
             lexer_callbacks={"COMMENT": add_comment},
             transformer=_AcfTransformer(filename, contents_hash, comments),
+            maybe_placeholders=False,
         )
 
         return grammar.parse(contents)

--- a/whatrecord/autosave.py
+++ b/whatrecord/autosave.py
@@ -53,6 +53,7 @@ class AutosaveRestoreFile:
             "autosave_save.lark",
             search_paths=("grammar", ),
             parser="earley",
+            maybe_placeholders=False,
             propagate_positions=True,
         )
 

--- a/whatrecord/bin/graph.py
+++ b/whatrecord/bin/graph.py
@@ -1,0 +1,166 @@
+"""
+"whatrecord graph" is used to parse and generate a relationship graph of
+whatrecord-supported file types.
+"""
+
+import argparse
+import logging
+import re
+from typing import Dict, List, Optional
+
+# from ..access_security import AccessSecurityConfig
+from ..common import AnyPath, RecordInstance  # , FileFormat, IocMetadata
+from ..db import Database
+# from ..dbtemplate import TemplateSubstitution
+# from ..format import FormatContext
+# from ..gateway import PVList as GatewayPVList
+from ..graph import build_database_relations, graph_links
+# from ..macro import MacroContext
+from ..shell import LoadedIoc
+# from ..snl import SequencerProgram
+# from ..streamdevice import StreamProtocol
+from .parse import parse_from_cli_args
+
+logger = logging.getLogger(__name__)
+DESCRIPTION = __doc__
+
+
+def build_arg_parser(parser=None):
+    if parser is None:
+        parser = argparse.ArgumentParser()
+
+    parser.description = DESCRIPTION
+    parser.formatter_class = argparse.RawTextHelpFormatter
+
+    parser.add_argument(
+        'filename',
+        type=str,
+        help="Startup script filename"
+    )
+
+    parser.add_argument(
+        "--format",
+        type=str,
+        required=False,
+        help=(
+            "The file format.  For files that lack a recognized extension or "
+            "are otherwise misidentified by whatrecord."
+        ),
+    )
+
+    parser.add_argument(
+        "--dbd",
+        type=str,
+        help="The dbd file, if parsing a database",
+    )
+
+    parser.add_argument(
+        "--standin-directory",
+        type=str,
+        nargs="*",
+        help='Map a "stand-in" directory to another on disk',
+    )
+
+    parser.add_argument(
+        "--macros",
+        type=str,
+        help="Macro to add, in the usual form ``macro=value,...``",
+    )
+
+    parser.add_argument(
+        "--friendly",
+        action="store_true",
+        help="Output Python object representation instead of JSON",
+    )
+
+    parser.add_argument(
+        "--friendly-format",
+        type=str,
+        default="console",
+        help="Output Python object representation instead of JSON",
+    )
+
+    parser.add_argument(
+        '--use-gdb',
+        action="store_true",
+        help="Use metadata derived from the script binary",
+    )
+
+    parser.add_argument(
+        "--expand",
+        action="store_true",
+        help="Expand a substitutions file, as in the msi tool",
+    )
+
+    parser.add_argument(
+        "--highlight",
+        nargs="*",
+        type=str,
+        default=(".*", ),
+        help="Highlight the provided regular expression matches",
+    )
+
+    return parser
+
+
+def main(
+    filename: AnyPath,
+    dbd: Optional[str] = None,
+    standin_directory: Optional[List[str]] = None,
+    macros: Optional[str] = None,
+    friendly: bool = False,
+    use_gdb: bool = False,
+    format: Optional[str] = None,
+    expand: bool = False,
+    friendly_format: str = "console",
+    highlight: Optional[List[str]] = None,
+    only: Optional[List[str]] = None,
+):
+    highlight = highlight or []
+    only = only or []
+    result = parse_from_cli_args(
+        filename=filename,
+        dbd=dbd,
+        standin_directory=standin_directory,
+        macros=macros,
+        use_gdb=use_gdb,
+        format=format,
+        expand=expand,
+    )
+
+    if isinstance(result, (LoadedIoc, Database)):
+        if isinstance(result, LoadedIoc):
+            database = result.shell_state.database
+            record_types = result.shell_state.database_definition.record_types
+            aliases = result.shell_state.aliases
+        else:
+            database = result.records
+            record_types = result.record_types
+            aliases = result.aliases
+
+        def records_by_patterns(patterns: List[str]) -> Dict[str, RecordInstance]:
+            return {
+                rec.name: rec
+                for rec in database.values()
+                if any(
+                    re.search(pattern, rec.name)
+                    for pattern in highlight
+                )
+            }
+
+        starting_records = records_by_patterns(highlight) if highlight else []
+        relations = build_database_relations(
+            database=database,
+            record_types=record_types,
+            aliases=aliases,
+        )
+        node, edges, graph = graph_links(
+            database=database,
+            starting_records=starting_records,
+            relations=relations,
+        )
+        print(graph.source)
+    else:
+        raise RuntimeError(
+            f"Sorry, graph isn't supported yet for {result.__class__.__name__}"
+        )

--- a/whatrecord/bin/graph.py
+++ b/whatrecord/bin/graph.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Optional
 
 # from ..access_security import AccessSecurityConfig
 from ..common import AnyPath, RecordInstance  # , FileFormat, IocMetadata
-from ..db import Database
+from ..db import Database, LinterResults
 # from ..dbtemplate import TemplateSubstitution
 # from ..format import FormatContext
 # from ..gateway import PVList as GatewayPVList
@@ -112,7 +112,7 @@ def build_arg_parser(parser=None):
 
 def _combine_databases(*items: Database) -> Database:
     for item in items:
-        if not isinstance(item, Database):
+        if not isinstance(item, (Database, LinterResults)):
             raise ValueError(f"Expected Database, got {type(item)}")
 
     db = items[0]
@@ -177,11 +177,16 @@ def main(
     else:
         result, = results
 
-    if isinstance(result, (LoadedIoc, Database)):
+    if isinstance(result, (LinterResults, LoadedIoc, Database)):
         if isinstance(result, LoadedIoc):
             database = result.shell_state.database
-            record_types = result.shell_state.database_definition.record_types
+            defn = result.shell_state.database_definition
+            record_types = defn.record_types if defn else None
             aliases = result.shell_state.aliases
+        elif isinstance(result, LinterResults):
+            database = result.records
+            record_types = result.record_types
+            aliases = {}
         else:
             database = result.records
             record_types = result.record_types

--- a/whatrecord/bin/main.py
+++ b/whatrecord/bin/main.py
@@ -16,7 +16,7 @@ import whatrecord
 DESCRIPTION = __doc__
 RETURN_VALUE = None
 
-MODULES = ("server", "iocmanager_loader", "info", "lint", "parse")
+MODULES = ("server", "iocmanager_loader", "info", "lint", "parse", "graph")
 
 
 def _try_import(module):

--- a/whatrecord/common.py
+++ b/whatrecord/common.py
@@ -606,6 +606,64 @@ def get_link_information(link_str: str) -> Tuple[str, Tuple[str, ...]]:
 
 
 LINK_TYPES = {"DBF_INLINK", "DBF_OUTLINK", "DBF_FWDLINK"}
+COMMON_LINK_FIELDS = ("FLNK", "SDIS", "TSEL")
+
+# Generate by way of: Database.field_names_by_type(LINK_TYPES)
+# Used when database definition files are not loaded; may not be complete
+# or 100% accurate depending on EPICS version.
+LINK_FIELDS_BY_RECORD = {
+    "aSub": ("FLNK", "INPA", "INPB", "INPC", "INPD", "INPE", "INPF", "INPG",
+             "INPH", "INPI", "INPJ", "INPK", "INPL", "INPM", "INPN", "INPO",
+             "INPP", "INPQ", "INPR", "INPS", "INPT", "INPU", "OUTA", "OUTB",
+             "OUTC", "OUTD", "OUTE", "OUTF", "OUTG", "OUTH", "OUTI", "OUTJ",
+             "OUTK", "OUTL", "OUTM", "OUTN", "OUTO", "OUTP", "OUTQ", "OUTR",
+             "OUTS", "OUTT", "OUTU", "SDIS", "SUBL", "TSEL"),
+    "aai": ("FLNK", "INP", "SDIS", "SIML", "SIOL", "TSEL"),
+    "aao": ("FLNK", "OUT", "SDIS", "SIML", "SIOL", "TSEL"),
+    "ai": ("FLNK", "INP", "SDIS", "SIML", "SIOL", "TSEL"),
+    "ao": ("DOL", "FLNK", "OUT", "SDIS", "SIML", "SIOL", "TSEL"),
+    "bi": ("FLNK", "INP", "SDIS", "SIML", "SIOL", "TSEL"),
+    "bo": ("DOL", "FLNK", "OUT", "SDIS", "SIML", "SIOL", "TSEL"),
+    "calc": ("FLNK", "INPA", "INPB", "INPC", "INPD", "INPE", "INPF", "INPG",
+             "INPH", "INPI", "INPJ", "INPK", "INPL", "SDIS", "TSEL"),
+    "calcout": ("FLNK", "INPA", "INPB", "INPC", "INPD", "INPE", "INPF", "INPG",
+                "INPH", "INPI", "INPJ", "INPK", "INPL", "OUT", "SDIS", "TSEL"),
+    "compress": ("FLNK", "INP", "SDIS", "TSEL"),
+    "dfanout": ("DOL", "FLNK", "OUTA", "OUTB", "OUTC", "OUTD", "OUTE", "OUTF",
+                "OUTG", "OUTH", "SDIS", "SELL", "TSEL"),
+    "event": ("FLNK", "INP", "SDIS", "SIML", "SIOL", "TSEL"),
+    "fanout": ("FLNK", "LNK0", "LNK1", "LNK2", "LNK3", "LNK4", "LNK5", "LNK6",
+               "LNK7", "LNK8", "LNK9", "LNKA", "LNKB", "LNKC", "LNKD", "LNKE",
+               "LNKF", "SDIS", "SELL", "TSEL"),
+    "histogram": ("FLNK", "SDIS", "SIML", "SIOL", "SVL", "TSEL"),
+    "int64in": ("FLNK", "INP", "SDIS", "SIML", "SIOL", "TSEL"),
+    "int64out": ("DOL", "FLNK", "OUT", "SDIS", "SIML", "SIOL", "TSEL"),
+    "longin": ("FLNK", "INP", "SDIS", "SIML", "SIOL", "TSEL"),
+    "longout": ("DOL", "FLNK", "OUT", "SDIS", "SIML", "SIOL", "TSEL"),
+    "lsi": ("FLNK", "INP", "SDIS", "SIML", "SIOL", "TSEL"),
+    "lso": ("DOL", "FLNK", "OUT", "SDIS", "SIML", "SIOL", "TSEL"),
+    "mbbi": ("FLNK", "INP", "SDIS", "SIML", "SIOL", "TSEL"),
+    "mbbiDirect": ("FLNK", "INP", "SDIS", "SIML", "SIOL", "TSEL"),
+    "mbbo": ("DOL", "FLNK", "OUT", "SDIS", "SIML", "SIOL", "TSEL"),
+    "mbboDirect": ("DOL", "FLNK", "OUT", "SDIS", "SIML", "SIOL", "TSEL"),
+    "permissive": ("FLNK", "SDIS", "TSEL"),
+    "printf": ("FLNK", "INP0", "INP1", "INP2", "INP3", "INP4", "INP5", "INP6",
+               "INP7", "INP8", "INP9", "OUT", "SDIS", "TSEL"),
+    "sel": ("FLNK", "INPA", "INPB", "INPC", "INPD", "INPE", "INPF", "INPG",
+            "INPH", "INPI", "INPJ", "INPK", "INPL", "NVL", "SDIS", "TSEL"),
+    "seq": ("DOL0", "DOL1", "DOL2", "DOL3", "DOL4", "DOL5", "DOL6", "DOL7",
+            "DOL8", "DOL9", "DOLA", "DOLB", "DOLC", "DOLD", "DOLE", "DOLF",
+            "FLNK", "LNK0", "LNK1", "LNK2", "LNK3", "LNK4", "LNK5", "LNK6",
+            "LNK7", "LNK8", "LNK9", "LNKA", "LNKB", "LNKC", "LNKD", "LNKE",
+            "LNKF", "SDIS", "SELL", "TSEL"),
+    "state": ("FLNK", "SDIS", "TSEL"),
+    "stringin": ("FLNK", "INP", "SDIS", "SIML", "SIOL", "TSEL"),
+    "stringout": ("DOL", "FLNK", "OUT", "SDIS", "SIML", "SIOL", "TSEL"),
+    "sub": ("FLNK", "INPA", "INPB", "INPC", "INPD", "INPE", "INPF", "INPG",
+            "INPH", "INPI", "INPJ", "INPK", "INPL", "SDIS", "TSEL"),
+    "subArray": ("FLNK", "INP", "SDIS", "TSEL"),
+    "waveform": ("FLNK", "INP", "SDIS", "SIML", "SIOL", "TSEL")
+}
 
 
 @dataclass
@@ -767,13 +825,49 @@ record("{{record_type}}", "{{name}}") {
     def get_links(
         self,
     ) -> Generator[Tuple[RecordField, str, Tuple[str, ...]], None, None]:
-        """Get all links."""
+        """
+        Get all links.
+
+        Yields
+        ------
+        field : RecordField
+        link_text: str
+        link_info: str
+        """
         for fld in self.get_fields_of_type(*LINK_TYPES):
             try:
                 link, info = get_link_information(fld.value)
             except ValueError:
                 continue
             yield fld, link, info
+
+    def get_common_links(
+        self,
+    ) -> Generator[Tuple[RecordField, str, Tuple[str, ...]], None, None]:
+        """
+        Without using a database definition, try to find links.
+
+        This differs from ``get_links`` in that the other method requires
+        a dbd file to be loaded, whereas this will use a simple - but possibly
+        inaccurate - map of of record type to link fields.
+
+        Yields
+        ------
+        field : RecordField
+        link_text: str
+        link_info: str
+        """
+        if self.is_pva:
+            return
+
+        for name in LINK_FIELDS_BY_RECORD.get(self.record_type, COMMON_LINK_FIELDS):
+            fld = self.fields.get(name, None)
+            if fld is not None:
+                try:
+                    link, info = get_link_information(fld.value)
+                except ValueError:
+                    continue
+                yield fld, link, info
 
     def to_summary(self) -> RecordInstanceSummary:
         """Return a summarized version of the record instance."""

--- a/whatrecord/db.py
+++ b/whatrecord/db.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import math
 import pathlib
 from dataclasses import field
-from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
+from typing import Any, Dict, FrozenSet, List, Mapping, Optional, Tuple, Union
 
 import apischema
 import lark
@@ -694,3 +694,26 @@ class Database:
                 version=version,
                 lint=lint,
             )
+
+    def field_names_by_type(
+        self, field_types: List[str]
+    ) -> Dict[str, FrozenSet[str]]:
+        """
+        Generate dictionary of record type to frozenset of field names.
+
+        This can be used in scenarios where database definition files are
+        unavailable and link information is requested.
+
+        Parameters
+        ----------
+        field_types : list of str
+            Field types to look for.
+        """
+        by_rtype = {}
+        for rtype, info in sorted(self.record_types.items()):
+            by_rtype[rtype] = frozenset(
+                field.name
+                for field in info.fields.values()
+                if field.type in field_types
+            )
+        return by_rtype

--- a/whatrecord/db.py
+++ b/whatrecord/db.py
@@ -638,6 +638,7 @@ class Database:
             parser="lalr",
             lexer_callbacks={"COMMENT": comments.append},
             transformer=_DatabaseTransformer(filename, dbd=dbd, lint=lint),
+            maybe_placeholders=False,
             # Per-user `gettempdir` caching of the LALR grammar analysis way of
             # passing ``True`` here:
             cache=True,

--- a/whatrecord/dbtemplate.py
+++ b/whatrecord/dbtemplate.py
@@ -266,7 +266,9 @@ class TemplateSubstitution:
             grammar_filename,
             search_paths=("grammar",),
             parser="earley",
-            lexer_callbacks={"COMMENT": comments.append},
+            # TODO: This is unsupported in lark:
+            # lexer_callbacks={"COMMENT": comments.append},
+            maybe_placeholders=False,
             propagate_positions=True,
         )
 

--- a/whatrecord/gateway.py
+++ b/whatrecord/gateway.py
@@ -249,6 +249,7 @@ class PVList:
             "gateway.lark",
             search_paths=("grammar", ),
             parser="lalr",
+            maybe_placeholders=False,
             lexer_callbacks={"COMMENT": add_comment},
             transformer=_PVListTransformer(filename, contents_hash, comments),
         )

--- a/whatrecord/snl.py
+++ b/whatrecord/snl.py
@@ -378,7 +378,9 @@ class SequencerProgram:
             "snl.lark",
             search_paths=("grammar",),
             parser="earley",
-            lexer_callbacks={"COMMENT": comments.append},
+            # TODO: alternative comment finding method
+            # lexer_callbacks={"COMMENT": comments.append},
+            maybe_placeholders=False,
             propagate_positions=True,
             debug=debug,
         )

--- a/whatrecord/streamdevice.py
+++ b/whatrecord/streamdevice.py
@@ -82,7 +82,8 @@ class StreamProtocol:
             "streamdevice.lark",
             search_paths=("grammar", ),
             parser="earley",
-            lexer_callbacks={"COMMENT": comments.append},
+            maybe_placeholders=False,
+            # lexer_callbacks={"COMMENT": comments.append},
         )
 
         proto = _ProtocolTransformer(cls, filename).transform(

--- a/whatrecord/tests/test_bin_graph.py
+++ b/whatrecord/tests/test_bin_graph.py
@@ -1,0 +1,44 @@
+"""Smoke tests to see if the provided IOCs load without crashing."""
+
+import pytest
+
+from ..bin.graph import main
+from . import conftest
+
+
+@conftest.startup_scripts
+def test_graph_smoke_startup_script(startup_script):
+    main(filenames=[startup_script])
+
+
+@pytest.mark.parametrize(
+    "with_dbd", [
+        pytest.param(True, id="with_dbd"),
+        pytest.param(False, id="without_dbd"),
+    ]
+)
+def test_graph_db(with_dbd):
+    db_path = conftest.MODULE_PATH / "iocs" / "streamdevice" / "test.db"
+    if with_dbd:
+        dbd_path = str(conftest.MODULE_PATH / "iocs" / "softIoc.dbd")
+    else:
+        dbd_path = None
+    main(filenames=[db_path], dbd=dbd_path)
+
+
+@pytest.mark.parametrize(
+    "with_dbd", [
+        pytest.param(True, id="with_dbd"),
+        pytest.param(False, id="without_dbd"),
+    ]
+)
+def test_graph_multiple_db(with_dbd):
+    db_paths = [
+        conftest.MODULE_PATH / "iocs" / "streamdevice" / "test.db",
+        conftest.MODULE_PATH / "iocs" / "ioc_a" / "ioc_a.db",
+    ]
+    if with_dbd:
+        dbd_path = str(conftest.MODULE_PATH / "iocs" / "softIoc.dbd")
+    else:
+        dbd_path = None
+    main(filenames=db_paths, dbd=dbd_path)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Add command-line support for:
```
$ whatrecord graph st.cmd
$ whatrecord graph database.db
```

## Motivation and Context
It'd be nice to not have to spawn up a server to investigate record links.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots (if appropriate):

Output of:
```
whatrecord graph pluginROI.db  --highlight "HOPR" |dot -Tpdf -O
```

![image](https://user-images.githubusercontent.com/5139267/142332323-75547476-31b3-4f86-80f3-a1f1f6886a90.png)
(internal link fields used here; no dbd required)