### PR TITLE
ENH/FIX: state notation language graphs + misc fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ addons:
     update: true
     packages:
       - gdb
+      - graphviz
 
 jobs:
   include:

--- a/whatrecord/bin/graph.py
+++ b/whatrecord/bin/graph.py
@@ -117,25 +117,7 @@ def _combine_databases(*items: Database) -> Database:
 
     db = items[0]
     for item in items[1:]:
-        for record, instance in item.records.items():
-            existing_record = db.records.get(record, None)
-            if not existing_record:
-                db.records[record] = instance
-            else:
-                existing_record.info.update(instance.info)
-                existing_record.metadata.update(instance.metadata)
-                existing_record.fields.update(instance.fields)
-                existing_record.aliases = list(
-                    sorted(set(existing_record.aliases + instance.aliases))
-                )
-                if existing_record.record_type != instance.record_type:
-                    logger.warning(
-                        "Record type mismatch in provided database files: "
-                        "%s %s %s",
-                        record, instance.record_type, existing_record.record_type
-                    )
-
-        db.record_types.update(item.record_types or {})
+        db.append(item)
 
     return db
 

--- a/whatrecord/bin/graph.py
+++ b/whatrecord/bin/graph.py
@@ -8,17 +8,11 @@ import logging
 import re
 from typing import Dict, List, Optional
 
-# from ..access_security import AccessSecurityConfig
 from ..common import AnyPath, RecordInstance  # , FileFormat, IocMetadata
 from ..db import Database, LinterResults
-# from ..dbtemplate import TemplateSubstitution
-# from ..format import FormatContext
-# from ..gateway import PVList as GatewayPVList
 from ..graph import build_database_relations, graph_links
-# from ..macro import MacroContext
 from ..shell import LoadedIoc
-# from ..snl import SequencerProgram
-# from ..streamdevice import StreamProtocol
+from ..snl import SequencerProgram
 from .parse import parse_from_cli_args
 
 logger = logging.getLogger(__name__)
@@ -190,13 +184,18 @@ def main(
             record_types=record_types,
             aliases=aliases,
         )
-        node, edges, graph = graph_links(
+        nodes, edges, graph = graph_links(
             database=database,
             starting_records=starting_records,
             relations=relations,
         )
-        print(graph.source)
+    elif isinstance(result, SequencerProgram):
+        nodes, edges, graph = result.as_graph()
     else:
         raise RuntimeError(
             f"Sorry, graph isn't supported yet for {result.__class__.__name__}"
         )
+
+    print(graph.source)
+    logger.debug("Nodes: %s", nodes)
+    logger.debug("Edges: %s", edges)

--- a/whatrecord/bin/parse.py
+++ b/whatrecord/bin/parse.py
@@ -279,13 +279,22 @@ def parse_from_cli_args(
             ioc_metadata
         )
 
+    try:
+        format = FileFormat(format) if format is not None else None
+    except ValueError:
+        options = [fmt.name for fmt in list(FileFormat)]
+        raise ValueError(
+            f"{format!r} is not a valid FileFormat. Options include: "
+            f"{options}"
+        )
+
     return parse(
         filename,
         dbd=dbd,
         standin_directories=standin_directories,
         macros=macros,
         use_gdb=use_gdb,
-        format=FileFormat(format) if format is not None else None,
+        format=format,
         expand=expand,
         v3=v3,
     )

--- a/whatrecord/common.py
+++ b/whatrecord/common.py
@@ -873,6 +873,45 @@ record("{{record_type}}", "{{name}}") {
         """Return a summarized version of the record instance."""
         return RecordInstanceSummary.from_record_instance(self)
 
+    def update(self, other: RecordInstance) -> List[LinterMessage]:
+        """
+        Update this record instance with another.
+
+        TODO: This may not do exactly what an IOC would do.
+        TODO: Return type?
+        """
+        if other.is_pva != self.is_pva:
+            return [
+                LinterError(
+                    name="combine_pva_and_v3",
+                    line=0,
+                    message="Cannot combine PVA group with V3 record"
+                )
+            ]
+        self.context = remove_redundant_context(
+            tuple(self.context) + tuple(other.context)
+        )
+        self.info.update(other.info)
+        self.metadata.update(other.metadata)
+        self.fields.update(other.fields)
+        self.aliases.extend(
+            [alias for alias in other.aliases if alias not in self.aliases]
+        )
+
+        if self.record_type != other.record_type:
+            return [
+                LinterError(
+                    name="record_type_mismatch",
+                    line=0,
+                    message=(
+                        f"Record type mismatch in provided database files: "
+                        f"{self.name} {self.record_type} {other.record_type}"
+                    ),
+                )
+            ]
+
+        return []
+
 
 class AsynPortBase:
     """

--- a/whatrecord/common.py
+++ b/whatrecord/common.py
@@ -1169,8 +1169,9 @@ def remove_redundant_context(full_context: FullLoadContext) -> FullLoadContext:
         else:
             zero_line_files.remove(file)
 
-    return tuple(
-        ctx
-        for ctx in full_context
-        if ctx.name not in zero_line_files or ctx.line > 0
-    )
+    new_context = []
+    for ctx in full_context:
+        is_specific = ctx.name not in zero_line_files or ctx.line > 0
+        if is_specific and ctx not in new_context:
+            new_context.append(ctx)
+    return tuple(new_context)

--- a/whatrecord/grammar/snl.lark
+++ b/whatrecord/grammar/snl.lark
@@ -227,13 +227,13 @@ init_declarators: _comma_separated{init_declarator}
 init_declarator: declarator (EQUAL init_expr)?
 
 declarator: variable
-          | declarator LPAREN param_decls RPAREN   -> declarator_decls
-          | declarator subscript                   -> declarator_subscript
-          | LPAREN declarator RPAREN               -> declarator_paren
-          | ASTERISK declarator                    -> declarator_deref
-          | CONST declarator                       -> declarator_const
+          | declarator LPAREN [ param_decls ] RPAREN   -> declarator_decls
+          | declarator subscript                       -> declarator_subscript
+          | LPAREN declarator RPAREN                   -> declarator_paren
+          | ASTERISK declarator                        -> declarator_deref
+          | CONST declarator                           -> declarator_const
 
-param_decls: _comma_separated{param_decl}?
+param_decls: _comma_separated{param_decl}
 
 // Allow parameter declaration with or without identifier
 param_decl: basetype declarator
@@ -282,8 +282,8 @@ type_expr: basetype abs_decl?
 
 // abstract_declarator
 abs_decl: abs_decl_mod
-        | abs_decl? subscript                  -> abs_decl_subscript
-        | abs_decl? LPAREN param_decls RPAREN  -> abs_decl_params
+        | [ abs_decl ] subscript                      -> abs_decl_subscript
+        | [ abs_decl ] LPAREN [ param_decls ] RPAREN  -> abs_decl_params
 
 // abstract declarator with some modification (), *, const
 abs_decl_mod: LPAREN abs_decl RPAREN
@@ -377,9 +377,9 @@ for_statement: FOR LPAREN [ comma_expr ] SEMICOLON [ comma_expr ] SEMICOLON [ co
 // Atomic
 ?expr: literal_expr
      | LPAREN comma_expr RPAREN       -> parenthesized_expr
-     | expr LPAREN args RPAREN        -> expr_with_args
+     | expr LPAREN [ comma_expr ] RPAREN        -> expr_with_args
      | expr LBRACKET expr RBRACKET    -> bracket_expr
-     | EXIT LPAREN args RPAREN        -> exit_expr
+     | EXIT LPAREN [ comma_expr ] RPAREN        -> exit_expr
      | SIZEOF LPAREN type_expr RPAREN -> sizeof
      | member_expr
      | unary_postfix_expr
@@ -443,8 +443,6 @@ binary_operator_expr: expr SUB expr  // Binary Operators, left-to-right
 comma_expr: _comma_separated{expr}
 
 // Function arguments
-// Syntactically the same as an optional expression but interpreted differently.
-args: [ _comma_separated{expr} ]
 
 string: STRCON
 member: NAME

--- a/whatrecord/grammar/snl.lark
+++ b/whatrecord/grammar/snl.lark
@@ -281,14 +281,14 @@ basetype: _prim_type
 type_expr: basetype abs_decl?
 
 // abstract_declarator
-abs_decl: abs_decl_mod
-        | [ abs_decl ] subscript                      -> abs_decl_subscript
-        | [ abs_decl ] LPAREN [ param_decls ] RPAREN  -> abs_decl_params
+?abs_decl: abs_decl_mod
+         | [ abs_decl ] subscript                      -> abs_decl_subscript
+         | [ abs_decl ] LPAREN [ param_decls ] RPAREN  -> abs_decl_params
 
 // abstract declarator with some modification (), *, const
 abs_decl_mod: LPAREN abs_decl RPAREN
-            | ASTERISK abs_decl?
-            | CONST abs_decl?
+            | ASTERISK [ abs_decl ]
+            | CONST [ abs_decl ]
 
 // not supported: empty brackets, empty parameter list
 // abs_decl: LBRACKET RBRACKET

--- a/whatrecord/grammar/snl.lark
+++ b/whatrecord/grammar/snl.lark
@@ -212,9 +212,9 @@ syncq: SYNCQ variable opt_subscript to event_flag syncq_size SEMICOLON -> syncq_
 event_flag: NAME
 variable: NAME
 
-syncq_size: INTCON?
+?syncq_size: INTCON?
 
-opt_subscript: subscript?
+?opt_subscript: subscript?
 
 subscript: LBRACKET INTCON RBRACKET
 
@@ -333,11 +333,9 @@ exit: (EXIT block)?
 
 transitions: transition+
 
-transition: WHEN LPAREN condition RPAREN block STATE NAME
-          | WHEN LPAREN condition RPAREN block EXIT        -> transition_exit
+transition: WHEN LPAREN [ comma_expr ] RPAREN block STATE NAME
+          | WHEN LPAREN [ comma_expr ] RPAREN block EXIT        -> transition_exit
 // | WHEN LPAREN condition RPAREN block error // report("expected 'state' or 'exit'\n");
-
-condition: opt_expr
 
 block: LBRACE block_defns statements RBRACE
 
@@ -352,20 +350,20 @@ statements: statement*
 
 statement: BREAK SEMICOLON                              -> break_statement
          | CONTINUE SEMICOLON                           -> continue_statement
-         | RETURN opt_expr SEMICOLON                    -> return_statement
+         | RETURN [ comma_expr ] SEMICOLON              -> return_statement
          | STATE NAME SEMICOLON                         -> state_statement
          | c_code
          | block
          | if_statement
          | WHILE LPAREN comma_expr RPAREN statement     -> while_statement
          | for_statement
-         | opt_expr SEMICOLON                           -> expr_statement
+         | [ comma_expr ] SEMICOLON                     -> expr_statement
 //       | error SEMICOLON(t).
 
 
-if_statement: IF LPAREN comma_expr RPAREN statement (ELSE statement)?
+if_statement: IF LPAREN comma_expr RPAREN statement ( ELSE statement )?
 
-for_statement: FOR LPAREN opt_expr SEMICOLON opt_expr SEMICOLON opt_expr RPAREN statement
+for_statement: FOR LPAREN [ comma_expr ] SEMICOLON [ comma_expr ] SEMICOLON [ comma_expr ] RPAREN statement
 
 // Expressions
 
@@ -373,8 +371,8 @@ for_statement: FOR LPAREN opt_expr SEMICOLON opt_expr SEMICOLON opt_expr RPAREN 
 // Comma separated lists of 'expr' can be: function arguments (non-terminal
 // 'args')and applications of the comma operator (non-terminal 'comma_expr').
 
-floating_point_literal: FPCON
-integer_literal: INTCON
+?floating_point_literal: FPCON
+?integer_literal: INTCON
 
 // Atomic
 ?expr: literal_expr
@@ -444,11 +442,9 @@ binary_operator_expr: expr SUB expr  // Binary Operators, left-to-right
 // Comma, left-to-right
 comma_expr: _comma_separated{expr}
 
-opt_expr: comma_expr?
-
 // Function arguments
-// Syntactically the same as opt_expr but interpreted differently.
-args: _comma_separated{expr}?
+// Syntactically the same as an optional expression but interpreted differently.
+args: [ _comma_separated{expr} ]
 
 string: STRCON
 member: NAME

--- a/whatrecord/graph.py
+++ b/whatrecord/graph.py
@@ -527,7 +527,7 @@ def graph_links(
     font_name: str = "Courier",
     relations: Optional[PVRelations] = None,
     record_types: Optional[Dict[str, RecordType]] = None,
-):
+) -> Tuple[dict, list, gv.Digraph]:
     """
     Create a graphviz digraph of record links.
 
@@ -565,7 +565,7 @@ def graph_links(
     Returns
     -------
     nodes: dict
-    edges: dict
+    edges: list
     graph : AsyncDigraph
     """
     node_id = 0

--- a/whatrecord/gv_compat.py
+++ b/whatrecord/gv_compat.py
@@ -1,0 +1,177 @@
+"""
+The following is borrowed from pygraphviz, reimplemented to allow for asyncio
+compatibility.
+
+Some form of it may move upstream at some point.  Requires graphviz<0.18 due
+to API changes.
+"""
+
+import asyncio
+import logging
+import os
+
+import graphviz as gv
+
+logger = logging.getLogger(__name__)
+
+
+async def async_render(
+    engine, format, filepath, renderer=None, formatter=None, quiet=False
+):
+    """
+    Async Render file with Graphviz ``engine`` into ``format``,  return result
+    filename.
+
+    Parameters
+    ----------
+    engine :
+        The layout commmand used for rendering (``'dot'``, ``'neato'``, ...).
+    format :
+        The output format used for rendering (``'pdf'``, ``'png'``, ...).
+    filepath :
+        Path to the DOT source file to render.
+    renderer :
+        The output renderer used for rendering (``'cairo'``, ``'gd'``, ...).
+    formatter :
+        The output formatter used for rendering (``'cairo'``, ``'gd'``, ...).
+    quiet : bool
+        Suppress ``stderr`` output from the layout subprocess.
+
+    Returns
+    -------
+    The (possibly relative) path of the rendered file.
+
+    Raises
+    ------
+    ValueError
+        If ``engine``, ``format``, ``renderer``, or ``formatter`` are not
+        known.
+
+    graphviz.RequiredArgumentError
+        If ``formatter`` is given but ``renderer`` is None.
+
+    graphviz.ExecutableNotFound
+        If the Graphviz executable is not found.
+
+    subprocess.CalledProcessError
+        If the exit status is non-zero.
+
+    Notes
+    -----
+    The layout command is started from the directory of ``filepath``, so that
+    references to external files (e.g. ``[image=...]``) can be given as paths
+    relative to the DOT source file.
+    """
+    # Adapted from graphviz under the MIT License (MIT) Copyright (c) 2013-2020
+    # Sebastian Bank
+    dirname, filename = os.path.split(filepath)
+    cmd, rendered = gv.backend.command(engine, format, filename, renderer, formatter)
+
+    if dirname:
+        cwd = dirname
+        rendered = os.path.join(dirname, rendered)
+    else:
+        cwd = None
+
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        cwd=cwd,
+    )
+
+    (stdout, stderr) = await proc.communicate()
+    if proc.returncode:
+        raise gv.backend.CalledProcessError(
+            proc.returncode, cmd, output=stdout, stderr=stderr
+        )
+    return rendered
+
+
+class AsyncDigraph(gv.Digraph):
+    async def async_render(
+        self,
+        filename=None,
+        directory=None,
+        view=False,
+        cleanup=False,
+        format=None,
+        renderer=None,
+        formatter=None,
+        quiet=False,
+        quiet_view=False,
+    ):
+        """
+        Save the source to file and render with the Graphviz engine.
+
+        Parameters
+        ----------
+        filename :
+            Filename for saving the source (defaults to ``name`` + ``'.gv'``)
+        directory :
+            (Sub)directory for source saving and rendering.
+        view (bool) :
+            Open the rendered result with the default application.
+        cleanup (bool) :
+            Delete the source file after rendering.
+        format :
+            The output format used for rendering (``'pdf'``, ``'png'``, etc.).
+        renderer :
+            The output renderer used for rendering (``'cairo'``, ``'gd'``, ...).
+        formatter :
+            The output formatter used for rendering (``'cairo'``, ``'gd'``, ...).
+        quiet (bool) :
+            Suppress ``stderr`` output from the layout subprocess.
+        quiet_view (bool) :
+            Suppress ``stderr`` output from the viewer process;
+           implies ``view=True``, ineffective on Windows.
+        Returns:
+            The (possibly relative) path of the rendered file.
+
+        Raises
+        ------
+        ValueError
+            If ``format``, ``renderer``, or ``formatter`` are not known.
+
+        graphviz.RequiredArgumentError
+            If ``formatter`` is given but ``renderer`` is None.
+
+        graphviz.ExecutableNotFound
+            If the Graphviz executable is not found.
+
+        subprocess.CalledProcessError
+            If the exit status is non-zero.
+
+        RuntimeError
+            If viewer opening is requested but not supported.
+
+        Notes
+        -----
+        The layout command is started from the directory of ``filepath``, so that
+        references to external files (e.g. ``[image=...]``) can be given as paths
+        relative to the DOT source file.
+        """
+        # Adapted from graphviz under the MIT License (MIT) Copyright (c) 2013-2020
+        # Sebastian Bank
+        filepath = self.save(filename, directory)
+
+        if format is None:
+            format = self._format
+
+        rendered = await async_render(
+            self._engine,
+            format,
+            filepath,
+            renderer=renderer,
+            formatter=formatter,
+            quiet=quiet,
+        )
+
+        if cleanup:
+            logger.debug("delete %r", filepath)
+            os.remove(filepath)
+
+        if quiet_view or view:
+            self._view(rendered, self._format, quiet_view)
+
+        return rendered

--- a/whatrecord/server/server.py
+++ b/whatrecord/server/server.py
@@ -430,13 +430,13 @@ class ServerState:
 
         if not pv_names:
             return graphviz.Digraph()
-        _, _, digraph = graph.graph_links(
+        gr = graph.graph_links(
             database=self.database,
-            starting_records=pv_names,
+            starting_records=list(pv_names),
             sort_fields=True,
-            font_name="Courier",
             relations=self.container.pv_relations,
         )
+        digraph = gr.to_digraph(font_name="Courier")
         return digraph
 
     def clear_cache(self):

--- a/whatrecord/server/server.py
+++ b/whatrecord/server/server.py
@@ -384,13 +384,12 @@ class ServerState:
 
         if not pv_names:
             return graphviz.Digraph()
-        _, _, digraph = graph.graph_script_relations(
+        gr = graph.graph_script_relations(
             database=self.database,
             limit_to_records=pv_names,
-            font_name="Courier",
             script_relations=self.script_relations,
         )
-        return digraph
+        return gr.to_digraph(font_name="Courier")
 
     def get_ioc_to_pvs(self, pv_names: Tuple[str, ...]) -> Dict[str, List[str]]:
         ioc_to_pvs = {}

--- a/whatrecord/snl.py
+++ b/whatrecord/snl.py
@@ -14,7 +14,6 @@ import lark
 
 from . import transformer
 from .common import AnyPath, FullLoadContext
-from .graph import AsyncDigraph
 from .transformer import context_from_token
 
 logger = logging.getLogger(__name__)
@@ -749,6 +748,7 @@ class SequencerProgramGraph:
         format :
             The output format used for rendering (``'pdf'``, ``'png'``, ...).
         """
+        from .graph import AsyncDigraph
         graph = graph or AsyncDigraph(format=format)
 
         if engine is not None:

--- a/whatrecord/snl.py
+++ b/whatrecord/snl.py
@@ -641,32 +641,10 @@ class SequencerProgramGraph(_GraphHelper):
                 label=f"(Line {transition.context[-1].line})",
             )
 
-    def to_digraph(
-        self,
-        graph: Optional[gv.Digraph] = None,
-        engine: str = "dot",
-        font_name: Optional[str] = "Courier",
-        format: str = "pdf",
-    ) -> gv.Digraph:
-        """
-        Create a graphviz digraph.
-
-        Parameters
-        ----------
-        graph : graphviz.Graph, optional
-            Graph instance to use.  New one created if not specified.
-        engine : str, optional
-            Graphviz engine (dot, fdp, etc).
-        font_name : str, optional
-            Font name to use for all nodes and edges.
-        format :
-            The output format used for rendering (``'pdf'``, ``'png'``, ...).
-        """
+    def _ready_for_digraph(self, graph: gv.Digraph):
+        """Hook when the user calls ``to_digraph``."""
         for node in self.nodes.values():
             node.highlighted = node.label in self.highlight_states
-        return super().to_digraph(
-            graph=graph, engine=engine, font_name=font_name, format=format
-        )
 
     def _add_transition(
         self,

--- a/whatrecord/snl.py
+++ b/whatrecord/snl.py
@@ -648,6 +648,20 @@ class SequencerProgramGraph(_GraphHelper):
         font_name: Optional[str] = "Courier",
         format: str = "pdf",
     ) -> gv.Digraph:
+        """
+        Create a graphviz digraph.
+
+        Parameters
+        ----------
+        graph : graphviz.Graph, optional
+            Graph instance to use.  New one created if not specified.
+        engine : str, optional
+            Graphviz engine (dot, fdp, etc).
+        font_name : str, optional
+            Font name to use for all nodes and edges.
+        format :
+            The output format used for rendering (``'pdf'``, ``'png'``, ...).
+        """
         for node in self.nodes.values():
             node.highlighted = node.label in self.highlight_states
         return super().to_digraph(

--- a/whatrecord/snl.py
+++ b/whatrecord/snl.py
@@ -683,7 +683,7 @@ class SequencerProgramGraph:
         qualified_name = f"{state_set.name}.{state.name}"
         self.get_node(
             qualified_name,
-            text="\n".join(self._get_state_node_text(state)),
+            text="\n".join(self._get_state_node_text(state_set, state)),
         )
 
         if state_set.states[0] is state:
@@ -787,8 +787,8 @@ class SequencerProgramGraph:
             return self.clean_code(str(obj)) or default
         return default
 
-    def _get_state_node_text(self, state: State):
-        yield f"<b>{state.name}</b>"
+    def _get_state_node_text(self, state_set: StateSet, state: State):
+        yield f"<b>{state_set.name}.{state.name}</b>"
         if self.include_code:
             if state.entry is not None:
                 yield "<u>Entry</u>"

--- a/whatrecord/snl.py
+++ b/whatrecord/snl.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import collections
+import html
 import logging
 import pathlib
 import shlex
+import textwrap
 from dataclasses import dataclass, field
-from typing import List, Optional, Sequence, Union
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import graphviz as gv
 import lark
@@ -28,14 +30,29 @@ class Expression:
     context: FullLoadContext
 
 
-OptionalExpression = Optional[Union[Expression, Sequence[Expression]]]
+@dataclass
+class CommaSeparatedExpressions(Expression):
+    expressions: List[Expression]
+
+    def __str__(self) -> str:
+        return ", ".join(str(item) for item in self.expressions)
+
+
+OptionalExpression = Optional[Union[Expression, CommaSeparatedExpressions]]
 
 
 @dataclass
 class Assignment(Definition):
     variable: str
     value: Optional[Union[str, Sequence[str]]] = None
-    subscript: Optional[int] = None
+    subscript: Optional[str] = None
+
+    def __str__(self) -> str:
+        if isinstance(self.value, tuple):
+            value = "{ " + ", ".join(str(s) for s in self.value) + "}"
+        else:
+            value = str(self.value)
+        return f"{self.variable}{self.subscript or ''} = {value};"
 
 
 @dataclass
@@ -45,6 +62,11 @@ class AbstractDeclarator:
     modifier: Optional[str] = None
     subscript: Optional[int] = None
 
+    def __str__(self) -> str:
+        raise NotImplementedError("TODO: abstractdeclarator cleanup")
+        # params = ", ".join(str(param) for param in self.params)
+        # return f"({params})"
+
 
 @dataclass
 class Type:
@@ -52,17 +74,27 @@ class Type:
     name: str
     abstract: Optional[AbstractDeclarator] = None
 
+    def __str__(self) -> str:
+        return f"{self.abstract or ''}{self.name}"
+
 
 @dataclass
 class Monitor(Definition):
     variable: str
     subscript: Optional[int]
 
+    def __str__(self) -> str:
+        return f"monitor {self.variable}{self.subscript or ''};"
+
 
 @dataclass
 class Option(Definition):
     name: str
     enable: bool
+
+    def __str__(self) -> str:
+        plus = "+" if self.enable else "-"
+        return f"option {plus}{self.name};"
 
 
 @dataclass
@@ -73,31 +105,59 @@ class Sync(Definition):
     event_flag: Optional[str] = None
     queue_size: Optional[int] = None
 
+    def __str__(self) -> str:
+        subscript = str(self.subscript or "")
+        variable = f"{self.variable}{subscript}"
+        event_flag = f" to {self.event_flag}" if self.event_flag else ""
+        if self.queued:
+            return f"syncq {variable}{event_flag} {self.queue_size or ''};"
+
+        return f"sync {variable}{event_flag};"
+
 
 @dataclass
 class Declaration(Definition):
     type: Optional[Type] = None
     declarators: Optional[Sequence[Declarator]] = field(default_factory=list)
 
+    def __str__(self) -> str:
+        declarators = ", ".join(str(decl) for decl in self.declarators or [])
+        return f"{self.type} {declarators};"
+
 
 @dataclass
 class ForeignDeclaration(Declaration):
     names: Sequence[str] = field(default_factory=list)
+
+    def __str__(self) -> str:
+        names = ", ".join(self.names)
+        return f"foreign {names};"
 
 
 @dataclass
 class Declarator:
     context: FullLoadContext
     object: Union[Declarator, Variable]
-    params: OptionalExpression = None
+    params: Optional[List[ParameterDeclarator]] = None
     value: Optional[Expression] = None
     modifier: Optional[str] = None
     subscript: Optional[int] = None
 
-
-@dataclass
-class Parameter:
-    context: FullLoadContext
+    def __str__(self) -> str:
+        if self.modifier == "()":
+            decl = f"({self.object})"
+        elif self.modifier:
+            decl = f"{self.modifier}{self.object}"
+        elif self.subscript:
+            decl = f"{self.object}{self.subscript}"
+        elif self.params:
+            params = ", ".join(str(param) for param in self.params)
+            decl = f"{self.object}({params})"
+        else:
+            decl = str(self.object)
+        if self.value:
+            return f"{decl} = {self.value}"
+        return f"{decl}"
 
 
 @dataclass
@@ -105,6 +165,11 @@ class ParameterDeclarator:
     context: FullLoadContext
     type: Type
     declarator: Optional[Declarator] = None
+
+    def __str__(self) -> str:
+        if self.declarator:
+            return f"{self.type} {self.declarator}"
+        return str(self.type)
 
 
 @dataclass
@@ -115,6 +180,28 @@ class State:
     transitions: Sequence[Transition] = field(default_factory=list)
     entry: Optional[Block] = None
     exit: Optional[Block] = None
+    code_transitions: List[StateStatement] = field(default_factory=list)
+
+    def __str__(self) -> str:
+        definitions = "\n".join(
+            str(defn)
+            for defn in self.definitions
+        )
+        transitions = "\n".join(
+            str(transition)
+            for transition in self.transitions
+        )
+        return "\n".join(
+            line for line in (
+                f"state {self.name}" + " {",
+                str(self.entry or ""),
+                textwrap.indent(definitions, " " * 4),
+                textwrap.indent(transitions, " " * 4),
+                str(self.exit or ""),
+                "}",
+            )
+            if line
+        )
 
 
 @dataclass
@@ -124,6 +211,24 @@ class StateSet:
     definitions: Sequence[Definition] = field(default_factory=list)
     states: Sequence[State] = field(default_factory=list)
 
+    def __str__(self) -> str:
+        definitions = "\n".join(
+            str(defn)
+            for defn in self.definitions
+        )
+        states = "\n".join(
+            str(state)
+            for state in self.states
+        )
+        return "\n".join(
+            (
+                f"ss {self.name}" + " {",
+                textwrap.indent(definitions, " " * 4),
+                textwrap.indent(states, " " * 4),
+                "}",
+            )
+        )
+
 
 @dataclass
 class Transition:
@@ -131,6 +236,22 @@ class Transition:
     block: Block
     target_state: Optional[str] = None
     condition: OptionalExpression = None
+
+    def __str__(self) -> str:
+        state = (
+            f"state {self.target_state}"
+            if self.target_state
+            else
+            "exit"
+        )
+        return "\n".join(
+            line for line in (
+                f"when ({self.condition or ''})" + " {",
+                str(self.block),
+                "}" + f" {state}",
+            )
+            if line
+        )
 
 
 @dataclass
@@ -144,6 +265,30 @@ class Block:
     definitions: Sequence[Definition] = field(default_factory=list)
     statements: Sequence[Statement] = field(default_factory=list)
 
+    def __str__(self) -> str:
+        definitions = textwrap.indent(
+            "\n".join(
+                str(defn)
+                for defn in self.definitions
+            ),
+            prefix="    ",
+        )
+        statements = textwrap.indent(
+            "\n".join(
+                str(statement)
+                for statement in self.statements
+            ),
+            prefix="    ",
+        )
+        return "\n".join(
+            (
+                "{",
+                definitions,
+                statements,
+                "}",
+            )
+        )
+
 
 @dataclass
 class Statement:
@@ -152,28 +297,41 @@ class Statement:
 
 @dataclass
 class BreakStatement(Statement):
-    ...
+    def __str__(self) -> str:
+        return "break;"
 
 
 @dataclass
 class ContinueStatement(Statement):
-    ...
+    def __str__(self) -> str:
+        return "continue;"
 
 
 @dataclass
 class ReturnStatement(Statement):
     value: Optional[Expression] = None
 
+    def __str__(self) -> str:
+        if self.value is not None:
+            return f"return {self.value};"
+        return "return;"
+
 
 @dataclass
 class StateStatement(Statement):
     name: str
 
+    def __str__(self) -> str:
+        return f"state {self.name};"
+
 
 @dataclass
 class WhileStatement(Statement):
-    condition: OptionalExpression
+    condition: CommaSeparatedExpressions
     body: Statement
+
+    def __str__(self) -> str:
+        return f"while ({self.condition}) " + str(self.body).lstrip()
 
 
 @dataclass
@@ -183,17 +341,45 @@ class ForStatement(Statement):
     increment: OptionalExpression
     statement: Statement
 
+    def __str__(self) -> str:
+        return (
+            f"for ({self.init or ''}; {self.condition or ''}; {self.increment or ''}) " +
+            str(self.statement).lstrip()
+        )
+
 
 @dataclass
 class ExpressionStatement(Statement):
-    expression: Expression
+    expression: CommaSeparatedExpressions
+
+    def __str__(self) -> str:
+        return f"{self.expression};"
 
 
 @dataclass
 class IfStatement(Statement):
-    condition: Expression
+    condition: CommaSeparatedExpressions
     body: Statement
     else_body: Optional[Statement] = None
+
+    def __str__(self) -> str:
+        else_clause = "\n".join(
+            (
+                "\nelse {",
+                textwrap.indent(str(self.else_body), " " * 4),
+                "}",
+            )
+            if self.else_body else ""
+        )
+
+        return "\n".join(
+            (
+                f"if ({self.condition}) " + " {",
+                textwrap.indent(str(self.body), " " * 4),
+                else_clause,
+                "}",
+            )
+        )
 
 
 @dataclass
@@ -202,23 +388,44 @@ class FuncDef(Definition):
     declarator: Declarator
     block: Block
 
+    def __str__(self) -> str:
+        return f"{self.type} {self.declarator};"
+
 
 @dataclass
-class StructMember:
+class StructMemberDecl:
     context: FullLoadContext
     type: Type
     declarator: Declarator
+
+    def __str__(self) -> str:
+        return f"{self.type} {self.declarator};"
 
 
 @dataclass
 class CCode(Definition):
     code: str
 
+    def __str__(self) -> str:
+        return self.code
+
 
 @dataclass
 class StructDef(Definition):
     name: str
-    members: Sequence[Union[StructMember, CCode]] = field(default_factory=list)
+    members: Sequence[Union[StructMemberDecl, CCode]] = field(default_factory=list)
+
+    def __str__(self) -> str:
+        members = "\n".join(
+            str(member) for member in self.members
+        )
+        return "\n".join(
+            (
+                f"struct {self.name}" + " {",
+                textwrap.indent(members, " " * 4),
+                "}",
+            )
+        )
 
 
 @dataclass
@@ -227,14 +434,6 @@ class Variable(Expression):
 
     def __str__(self) -> str:
         return self.name
-
-
-def _optional_expression_to_string(expr: OptionalExpression) -> str:
-    if expr is None:
-        return ""
-    if isinstance(expr, Sequence):
-        return ", ".join(str(item) for item in expr)
-    return str(expr)
 
 
 @dataclass
@@ -252,6 +451,11 @@ class InitExpression(Expression):
         default_factory=list
     )
     type: Optional[Type] = None
+
+    def __str__(self) -> str:
+        exprs = ", ".join(str(expr or '') for expr in self.expressions)
+        type_prefix = f"({self.type}) " if self.type else ""
+        return f"{type_prefix}{{ {exprs} }}"
 
 
 @dataclass
@@ -332,13 +536,19 @@ class SizeofExpression(Expression):
 
 @dataclass
 class ExitExpression(Expression):
-    expression: Expression
+    args: OptionalExpression
+
+    def __str__(self) -> str:
+        return f"exit({self.args or ''})"
 
 
 @dataclass
 class BracketedExpression(Expression):
     outer: Expression
     inner: Expression
+
+    def __str__(self) -> str:
+        return f"{self.outer}[{self.inner}]"
 
 
 @dataclass
@@ -355,8 +565,237 @@ class ExpressionWithArguments(Expression):
     arguments: OptionalExpression = None
 
     def __str__(self) -> str:
-        args = _optional_expression_to_string(self.arguments)
-        return f"{self.expression}({args})"
+        return f"{self.expression}({self.arguments or ''})"
+
+
+@dataclass
+class _SequencerProgramGraphNode:
+    #: The integer ID of the node
+    id: str
+    #: The node label
+    label: str
+    #: The text to show in the node
+    text: str
+
+
+@dataclass
+class _SequencerProgramGraphEdge:
+    #: The integer ID of the node
+    source: _SequencerProgramGraphNode
+    #: The node label
+    destination: _SequencerProgramGraphNode
+    #: The text to show in the node
+    options: dict
+
+
+class SequencerProgramGraph:
+    """
+    A graph for a SequencerProgram.
+
+    Parameters
+    ----------
+    program : SequencerProgram, optional
+        A program to add.
+
+    highlight_states : list of str, optional
+        List of state names to highlight.
+
+    include_code : bool, optional
+        Include code, where relevant, in nodes.
+    """
+
+    shapes: Tuple[str, str] = ("rectangle", "box3d")
+    fill_colors: Tuple[str, str] = ("white", "bisque")
+    newline: str = '<br align="left"/>'
+    nodes: Dict[str, _SequencerProgramGraphNode]
+    edges: List[_SequencerProgramGraphEdge]
+    _entry_label: str = "_Entry_"
+    _exit_label: str = "_Exit_"
+
+    def __init__(
+        self,
+        program: Optional[SequencerProgram] = None,
+        highlight_states: Optional[List[str]] = None,
+        include_code: bool = False,
+    ):
+        self._node_id = 0
+        self.nodes = {}
+        self.edges = []
+        self.include_code = include_code
+        self.highlight_states = highlight_states or []
+        if program is not None:
+            self.add_program(program)
+
+    def get_node(
+        self, label: str, text: Optional[str] = None
+    ) -> _SequencerProgramGraphNode:
+        """Create a new node in the graph."""
+        if label not in self.nodes:
+            self._node_id += 1
+            self.nodes[label] = _SequencerProgramGraphNode(
+                id=str(self._node_id),
+                text=text or label,
+                label=label
+            )
+            logger.debug("Created node %s", label)
+
+        self.nodes[label].text = text or self.nodes[label].text
+        return self.nodes[label]
+
+    def add_edge(
+        self,
+        source: str,
+        destination: str,
+        **options
+    ) -> _SequencerProgramGraphEdge:
+        """Create a new edge in the graph."""
+        edge = _SequencerProgramGraphEdge(
+            self.get_node(source),
+            self.get_node(destination),
+            options
+        )
+        self.edges.append(
+            edge
+        )
+        return edge
+
+    def add_program(self, program: SequencerProgram):
+        """Add a program to the graph."""
+        for state_set in program.state_sets:
+            for state in state_set.states:
+                self._add_state(program, state_set, state)
+
+        # Only add entry/exit labels if there's an edge
+        if self._entry_label in self.nodes:
+            self.get_node(
+                self._entry_label,
+                self.get_code(program.entry, "(Startup)")
+            )
+
+        if self._exit_label in self.nodes:
+            self.get_node(
+                self._exit_label,
+                self.get_code(program.exit, "(Exit)")
+            )
+
+    def _add_state(self, program: SequencerProgram, state_set: StateSet, state: State):
+        """Add a state set's state to the graph."""
+        qualified_name = f"{state_set.name}.{state.name}"
+        self.get_node(
+            qualified_name,
+            text="\n".join(self._get_state_node_text(state)),
+        )
+
+        if state_set.states[0] is state:
+            self.add_edge(
+                self._entry_label,
+                qualified_name,
+            )
+
+        for transition in state.transitions:
+            self._add_transition(program, state_set, state, transition)
+
+        for transition in state.code_transitions:
+            self.add_edge(
+                qualified_name,
+                f"{state_set.name}.{transition.name}",
+                label=f"(Line {transition.context[-1].line})",
+            )
+
+    def _add_transition(
+        self,
+        program: SequencerProgram,
+        state_set: StateSet,
+        state: State,
+        transition: Transition,
+    ):
+        """Add a state set's state transition to the graph."""
+        state_qualified_name = f"{state_set.name}.{state.name}"
+        label = str(transition.condition or "")
+        transition_text = self.get_code(transition.block)
+        target_state = (
+            f"{state_set.name}.{transition.target_state}"
+            if transition.target_state
+            else self._exit_label
+        )
+        if not self.include_code or not transition_text:
+            self.add_edge(state_qualified_name, target_state, label=label)
+            return
+
+        transition_idx = state.transitions.index(transition)
+        transition_node = f"{state_qualified_name}.{transition_idx}"
+        self.get_node(transition_node, text=transition_text)
+        self.add_edge(state_qualified_name, transition_node, label=label)
+        self.add_edge(transition_node, target_state)
+
+    def to_digraph(
+        self,
+        graph: Optional[gv.Digraph] = None,
+        engine: str = "dot",
+        font_name: Optional[str] = "Courier",
+        format: str = "pdf",
+    ) -> gv.Digraph:
+        """
+        Create a graphviz digraph.
+
+        Parameters
+        ----------
+        graph : graphviz.Graph, optional
+            Graph instance to use.  New one created if not specified.
+        engine : str, optional
+            Graphviz engine (dot, fdp, etc).
+        font_name : str, optional
+            Font name to use for all nodes and edges.
+        format :
+            The output format used for rendering (``'pdf'``, ``'png'``, ...).
+        """
+        graph = graph or AsyncDigraph(format=format)
+
+        if engine is not None:
+            graph.engine = engine
+
+        if font_name is not None:
+            graph.attr("graph", fontname=font_name)
+            graph.attr("node", fontname=font_name)
+            graph.attr("edge", fontname=font_name)
+
+        for node in self.nodes.values():
+            text = self.newline.join(node.text.splitlines())
+            highlighted = node.label in self.highlight_states
+            graph.node(
+                node.id,
+                label="< {} >".format(text),
+                shape=self.shapes[highlighted],
+                fillcolor=self.fill_colors[highlighted],
+                style="filled",
+            )
+
+        # add all of the edges between graphs
+        for edge in self.edges:
+            graph.edge(edge.source.id, edge.destination.id, **edge.options)
+        return graph
+
+    @staticmethod
+    def clean_code(obj):
+        """Clean C-like code for graphviz."""
+        code = str(obj or "").strip("{}")
+        return html.escape(textwrap.dedent(code).strip(" \n"))
+
+    def get_code(self, obj, default: str = ""):
+        """Get code for a node/edge."""
+        if self.include_code and obj is not None:
+            return self.clean_code(str(obj)) or default
+        return default
+
+    def _get_state_node_text(self, state: State):
+        yield f"<b>{state.name}</b>"
+        if self.include_code:
+            if state.entry is not None:
+                yield "<u>Entry</u>"
+                yield self.clean_code(state.entry)
+            if state.exit is not None:
+                yield "<u>Exit</u>"
+                yield self.clean_code(state.exit)
 
 
 @dataclass
@@ -371,6 +810,32 @@ class SequencerProgram:
     state_sets: Sequence[StateSet] = field(default_factory=list)
     exit: Optional[Block] = None
     final_definitions: Sequence[Definition] = field(default_factory=list)
+
+    def __str__(self) -> str:
+        initial_definitions = "\n".join(
+            str(defn)
+            for defn in self.initial_definitions
+        )
+        final_definitions = "\n".join(
+            str(defn)
+            for defn in self.final_definitions
+        )
+        state_sets = "\n\n".join(
+            str(state_set)
+            for state_set in self.state_sets
+        )
+        param = f"({self.params})" if self.params else ""
+        return "\n\n".join(
+            line for line in (
+                f"program {self.name}{param}",
+                initial_definitions,
+                str(self.entry or ""),
+                state_sets,
+                str(self.exit or ""),
+                final_definitions,
+            )
+            if line
+        )
 
     @staticmethod
     def preprocess(code: str, search_path: Optional[AnyPath] = None) -> str:
@@ -471,122 +936,15 @@ class SequencerProgram:
         with open(fn, "rt") as fp:
             return cls.from_string(fp.read(), filename=fn)
 
-    def as_graph(
-        self,
-        graph: Optional[gv.Digraph] = None,
-        engine: str = "dot",
-        font_name: str = "Courier",
-        highlight_states: Optional[List[str]] = None,
-    ):
+    def as_graph(self, **kwargs) -> SequencerProgramGraph:
         """
-        Create a graphviz digraph of script links (i.e., inter-IOC record links).
-
-        Parameters
-        ----------
-        graph : graphviz.Graph, optional
-            Graph instance to use. New one created if not specified.
-        engine : str, optional
-            Graphviz engine (dot, fdp, etc)
+        Create a graphviz digraph of the state notation diagram.
 
         Returns
         -------
-        nodes: dict
-        edges: dict
-        graph : graphviz.Digraph
+        graph : SequencerProgramGraph
         """
-        node_id = 0
-        edges = []
-        nodes = {}
-
-        highlight_states = highlight_states or []
-        if graph is None:
-            graph = AsyncDigraph(format="pdf")
-
-        if font_name is not None:
-            graph.attr("graph", fontname=font_name)
-            graph.attr("node", fontname=font_name)
-            graph.attr("edge", fontname=font_name)
-
-        if engine is not None:
-            graph.engine = engine
-
-        newline = '<br align="center"/>'
-
-        def new_node(label, text=None):
-            nonlocal node_id
-            if label in nodes:
-                return nodes[label]
-            node_id += 1
-            nodes[label] = dict(
-                id=str(node_id),
-                text=text or [label],
-                label=label
-            )
-            logger.debug("Created node %s", label)
-            return node_id
-
-        new_node(
-            "_Entry_",
-            [
-                "(Startup)"
-                if self.entry is None else
-                "Entry block"
-            ]
-        )
-
-        new_node(
-            "_Exit_",
-            [
-                "(Exit)"
-                if self.exit is None else
-                "Exit block"
-            ]
-        )
-
-        for state_set in self.state_sets:
-            for state in state_set.states:
-                qualified_name = f"{state_set.name}.{state.name}"
-                new_node(qualified_name)
-
-                for transition in state.transitions:
-                    label = _optional_expression_to_string(transition.condition)
-                    edges.append(
-                        (
-                            qualified_name,
-                            f"{state_set.name}.{transition.target_state}",
-                            dict(label=label),
-                        )
-                    )
-                # TODO
-                # if state.entry is not None:
-                #     new_node(qualified_name)
-
-        if self.state_sets and self.state_sets[0].states:
-            first_ss = self.state_sets[0]
-            edges.append(
-                (
-                    "_Entry_",
-                    f"{first_ss.name}.{first_ss.states[0].name}",
-                    {}
-                )
-            )
-            self.state_sets[0].states[0].name
-
-        for name, node in sorted(nodes.items()):
-            text = newline.join(node["text"])
-            graph.node(
-                node["id"],
-                label="< {} >".format(text),
-                shape="box3d" if name in highlight_states else "rectangle",
-                fillcolor="bisque" if name in highlight_states else "white",
-                style="filled",
-            )
-
-        # add all of the edges between graphs
-        for src, dest, options in edges:
-            graph.edge(nodes[src]["id"], nodes[dest]["id"], **options)
-
-        return nodes, edges, graph
+        return SequencerProgramGraph(self, **kwargs)
 
 
 @lark.visitors.v_args(inline=True)
@@ -597,9 +955,7 @@ class _ProgramTransformer(lark.visitors.Transformer):
         )
         self.fn = str(fn)
         self.cls = cls
-
-    # def __default__(self, data, children, meta):
-    #     raise RuntimeError(f"Unhandled {data}")
+        self._code_transitions = []
 
     def program(
         self,
@@ -862,7 +1218,7 @@ class _ProgramTransformer(lark.visitors.Transformer):
             name=" ".join(type_info),
         )
 
-    def type_expr(self, basetype, abs_decl=None):
+    def type_expr(self, basetype: Type, abs_decl: Optional[AbstractDeclarator] = None):
         basetype.abstract = abs_decl
         return basetype
 
@@ -878,30 +1234,26 @@ class _ProgramTransformer(lark.visitors.Transformer):
 
         return token
 
-    def abs_decl_subscript(self, *args):
+    def abs_decl_subscript(self, abs_decl, subscript):
         # TODO I think these may be wrong
-        if len(args) == 1:
-            (subscript,) = args
+        if abs_decl is None:
             return AbstractDeclarator(
                 context=context_from_token(self.fn, subscript),
                 subscript=str(subscript),
             )
 
-        decl, subscript = args
-        decl.subscript = subscript
-        return decl
+        abs_decl.subscript = subscript
+        return abs_decl
 
-    def abs_decl_params(self, *args):
+    def abs_decl_params(self, abs_decl, lparen, param_decls, rparen):
         """
         abs_decl? LPAREN param_decls RPAREN
         """
         # TODO I think these may be wrong
-        if len(args) == 4:
-            abs_decl, lparen, param_decls, _ = args
+        if abs_decl is not None:
             abs_decl.params = param_decls
             return abs_decl
 
-        lparen, param_decls, _ = args
         return AbstractDeclarator(
             context=context_from_token(self.fn, lparen),
             params=param_decls,
@@ -949,6 +1301,8 @@ class _ProgramTransformer(lark.visitors.Transformer):
         """
         STATE NAME LBRACE state_defns entry? transitions exit? RBRACE
         """
+        code_transitions = list(self._code_transitions)
+        self._code_transitions = []
         return State(
             context=context_from_token(self.fn, state_token),
             name=str(name),
@@ -956,6 +1310,7 @@ class _ProgramTransformer(lark.visitors.Transformer):
             entry=entry,
             transitions=transitions,
             exit=exit,
+            code_transitions=code_transitions,
         )
 
     state_defns = transformer.tuple_args
@@ -1034,10 +1389,12 @@ class _ProgramTransformer(lark.visitors.Transformer):
         )
 
     def state_statement(self, state_token: lark.Token, name: lark.Token, _):
-        return StateStatement(
+        statement = StateStatement(
             context=context_from_token(self.fn, state_token),
             name=str(name),
         )
+        self._code_transitions.append(statement)
+        return statement
 
     def while_statement(
         self,
@@ -1053,7 +1410,7 @@ class _ProgramTransformer(lark.visitors.Transformer):
             body=statement,
         )
 
-    def expr_statement(self, expression: Expression, semicolon: lark.Token):
+    def expr_statement(self, expression: CommaSeparatedExpressions, semicolon: lark.Token):
         return ExpressionStatement(
             context=context_from_token(self.fn, semicolon),
             expression=expression,
@@ -1065,7 +1422,7 @@ class _ProgramTransformer(lark.visitors.Transformer):
         self,
         if_token: lark.Token,
         _,
-        condition: Expression,
+        condition: OptionalExpression,
         __,
         body: Expression,
         *else_clause
@@ -1145,10 +1502,10 @@ class _ProgramTransformer(lark.visitors.Transformer):
             type=type_expr,
         )
 
-    def exit_expr(self, exit_token: lark.Token, _, expr: Expression, __):
+    def exit_expr(self, exit_token: lark.Token, _, args: OptionalExpression, __):
         return ExitExpression(
             context=context_from_token(self.fn, exit_token),
-            expression=expr,
+            args=args,
         )
 
     def expr_with_args(
@@ -1199,6 +1556,12 @@ class _ProgramTransformer(lark.visitors.Transformer):
             name=str(name),
         )
 
+    def comma_expr(self, *expressions: Expression) -> CommaSeparatedExpressions:
+        return CommaSeparatedExpressions(
+            context=expressions[0].context,
+            expressions=list(expressions),
+        )
+
     @lark.visitors.v_args(tree=True)
     def literal_expr(self, item):
         child = item.children[0]
@@ -1214,8 +1577,6 @@ class _ProgramTransformer(lark.visitors.Transformer):
             # [Tree('variable', [Token('NAME', 'seq_test_init')])]
             value=value,
         )
-
-    comma_expr = transformer.tuple_args
 
     args = transformer.tuple_args
 
@@ -1255,7 +1616,7 @@ class _ProgramTransformer(lark.visitors.Transformer):
         """
         basetype declarator SEMICOLON
         """
-        return StructMember(
+        return StructMemberDecl(
             context=type.context,
             type=type,
             declarator=declarator,

--- a/whatrecord/tests/test_bin_graph.py
+++ b/whatrecord/tests/test_bin_graph.py
@@ -8,7 +8,7 @@ from . import conftest
 
 @conftest.startup_scripts
 def test_graph_smoke_startup_script(startup_script):
-    main(filenames=[startup_script])
+    main(filenames=[startup_script], highlight=[".*"])
 
 
 @pytest.mark.parametrize(
@@ -23,7 +23,7 @@ def test_graph_db(with_dbd):
         dbd_path = str(conftest.MODULE_PATH / "iocs" / "softIoc.dbd")
     else:
         dbd_path = None
-    main(filenames=[db_path], dbd=dbd_path)
+    main(filenames=[db_path], dbd=dbd_path, highlight=[".*"])
 
 
 @pytest.mark.parametrize(
@@ -41,4 +41,4 @@ def test_graph_multiple_db(with_dbd):
         dbd_path = str(conftest.MODULE_PATH / "iocs" / "softIoc.dbd")
     else:
         dbd_path = None
-    main(filenames=db_paths, dbd=dbd_path)
+    main(filenames=db_paths, dbd=dbd_path, highlight=[".*"])

--- a/whatrecord/tests/test_snl.py
+++ b/whatrecord/tests/test_snl.py
@@ -16,23 +16,25 @@ if additional_files.exists():
         SNL_FILES.append(pathlib.Path(additional))
 
 
-snl_filenames = pytest.mark.parametrize(
-    "program_filename",
-    [
-        pytest.param(
-            program_filename,
-            id="/".join(program_filename.parts[-2:])
-        )
-        for program_filename in SNL_FILES
-    ]
+SNL_IDS = [
+    "/".join(program_filename.parts[-2:])
+    for program_filename in SNL_FILES
+]
+
+
+@pytest.fixture(
+    params=SNL_FILES,
+    ids=SNL_IDS,
 )
+def snl_filename(request) -> pathlib.Path:
+    return request.param
 
 
-@snl_filenames
-def test_parse(program_filename):
-    with open(program_filename, "rt") as fp:
+@pytest.fixture
+def snl_program(snl_filename) -> SequencerProgram:
+    with open(snl_filename, "rt") as fp:
         source = SequencerProgram.preprocess(
-            fp.read(), search_path=program_filename.parent
+            fp.read(), search_path=snl_filename.parent
         )
     has_program = any(
         line.startswith("program")
@@ -44,18 +46,35 @@ def test_parse(program_filename):
             "(perhaps it's meant to be included from another?)"
         )
 
-    program = SequencerProgram.from_file(program_filename)
+    return SequencerProgram.from_file(snl_filename)
 
+
+def test_parse(snl_program: SequencerProgram):
     # from ..format import FormatContext
     # ctx = FormatContext()
     # print(ctx.render_object(program, "console"))
-    print(program)
+    print(snl_program)
 
-    serialized = apischema.serialize(program)
+    serialized = apischema.serialize(snl_program)
     # pprint.pprint(serialized)
     apischema.deserialize(SequencerProgram, serialized)
     # deserialized = apischema.deserialize(SequencerProgram, serialized)
-    # assert deserialized == program
+    # assert deserialized == snl_program
+
+    round_trip = str(snl_program)
+    print("Round-tripped to")
+    print(round_trip)
+    assert "(context=(" not in round_trip
+    assert "(Tree=(" not in round_trip
+    assert "(Token=(" not in round_trip
+
+
+def test_graph(snl_filename: pathlib.Path, snl_program: SequencerProgram):
+    graph = snl_program.as_graph()
+    digraph = graph.to_digraph()
+
+    from ..bin.graph import render_graph_to_file
+    render_graph_to_file(digraph, filename=f"{snl_filename}.pdf")
 
 
 @pytest.mark.parametrize(

--- a/whatrecord/tests/test_snl.py
+++ b/whatrecord/tests/test_snl.py
@@ -54,6 +54,8 @@ def test_parse(program_filename):
     serialized = apischema.serialize(program)
     # pprint.pprint(serialized)
     apischema.deserialize(SequencerProgram, serialized)
+    # deserialized = apischema.deserialize(SequencerProgram, serialized)
+    # assert deserialized == program
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Add graphviz plotting for EPICS state notation language programs.
* Add helper base class to be used for all graphs supported by whatrecord (PVs, scripts, state notation language)
* Cleans up `whatrecord graph` entrypoint; the following are now valid:
   * `whatrecord graph simple.st -o test.png`
   * `whatrecord graph *.db -o test.png`
* SNL grammar somewhat round-trippable (modulo comments and formatting)
* Works, but formatting / display could use improvement

## Motivation and Context
These programs can be difficult to interpret.  Even for simple cases, this can be useful.

## How Has This Been Tested?
Against a suite of programs I rounded up from existing IOCs a while back.

## Where Has This Been Documented?
This PR text. And #105 

## Screenshots (if appropriate):

One without code:
![image](https://user-images.githubusercontent.com/5139267/155245786-1f7ec420-752c-46d5-9df9-41954ebe29dc.png)

One with code:
![image](https://user-images.githubusercontent.com/5139267/155245927-5aded6a8-5983-47b1-9811-190dafe4b2ad.png)
