### PR TITLE
FIX: fix and clean record graphs + arrow direction using test-suite vendored dbd files

### DIFF
--- a/whatrecord/bin/graph.py
+++ b/whatrecord/bin/graph.py
@@ -207,6 +207,11 @@ def main(
 
     if databases_only:
         graph = get_database_graph(*loaded_items, highlight=highlight)
+        if not graph.nodes:
+            logger.warning(
+                "No records found matching the highlight settings: %s",
+                highlight
+            )
     else:
         try:
             item, = loaded_items

--- a/whatrecord/common.py
+++ b/whatrecord/common.py
@@ -550,8 +550,21 @@ field({{name}}, "{{value}}")  # {{dtype}}{% if context %}; {{context[-1]}}{% end
 """,
     }
 
-    def update_unknowns(self, other: RecordField, *, unknown_values=None,
-                        dbd=None):
+    def update_from_record_type(
+        self,
+        record_type: RecordType
+    ):
+        """Update field information given dbd-provided information."""
+        record_type_field = record_type.fields.get(self.name, None)
+        if record_type_field is not None:
+            self.dtype = record_type_field.type
+
+    def update_unknowns(
+        self,
+        other: RecordField,
+        *,
+        unknown_values: Optional[Sequence[str]] = None,
+    ):
         """
         If this RecordField has some missing information ("unknown"), fill
         it in with information from the other field.
@@ -566,7 +579,6 @@ field({{name}}, "{{value}}")  # {{dtype}}{% if context %}; {{context[-1]}}{% end
             if ctx.name in unknown_values:
                 # Even if the other context is unknown, let's take it anyway:
                 self.context = other.context
-        # if dbd is not None:
 
 
 PVRelations = Dict[

--- a/whatrecord/common.py
+++ b/whatrecord/common.py
@@ -581,8 +581,11 @@ field({{name}}, "{{value}}")  # {{dtype}}{% if context %}; {{context[-1]}}{% end
                 self.context = other.context
 
 
+# field1, field2, options (CA, CP, CPP, etc.)
+FieldRelation = Tuple[RecordField, RecordField, List[str]]
+
 PVRelations = Dict[
-    str, Dict[str, List[Tuple[RecordField, RecordField, List[str]]]]
+    str, Dict[str, List[FieldRelation]]
 ]
 
 

--- a/whatrecord/common.py
+++ b/whatrecord/common.py
@@ -614,64 +614,6 @@ def get_link_information(link_str: str) -> Tuple[str, List[str]]:
 
 
 LINK_TYPES = {"DBF_INLINK", "DBF_OUTLINK", "DBF_FWDLINK"}
-COMMON_LINK_FIELDS = ("FLNK", "SDIS", "TSEL")
-
-# Generate by way of: Database.field_names_by_type(LINK_TYPES)
-# Used when database definition files are not loaded; may not be complete
-# or 100% accurate depending on EPICS version.
-LINK_FIELDS_BY_RECORD = {
-    "aSub": ("FLNK", "INPA", "INPB", "INPC", "INPD", "INPE", "INPF", "INPG",
-             "INPH", "INPI", "INPJ", "INPK", "INPL", "INPM", "INPN", "INPO",
-             "INPP", "INPQ", "INPR", "INPS", "INPT", "INPU", "OUTA", "OUTB",
-             "OUTC", "OUTD", "OUTE", "OUTF", "OUTG", "OUTH", "OUTI", "OUTJ",
-             "OUTK", "OUTL", "OUTM", "OUTN", "OUTO", "OUTP", "OUTQ", "OUTR",
-             "OUTS", "OUTT", "OUTU", "SDIS", "SUBL", "TSEL"),
-    "aai": ("FLNK", "INP", "SDIS", "SIML", "SIOL", "TSEL"),
-    "aao": ("FLNK", "OUT", "SDIS", "SIML", "SIOL", "TSEL"),
-    "ai": ("FLNK", "INP", "SDIS", "SIML", "SIOL", "TSEL"),
-    "ao": ("DOL", "FLNK", "OUT", "SDIS", "SIML", "SIOL", "TSEL"),
-    "bi": ("FLNK", "INP", "SDIS", "SIML", "SIOL", "TSEL"),
-    "bo": ("DOL", "FLNK", "OUT", "SDIS", "SIML", "SIOL", "TSEL"),
-    "calc": ("FLNK", "INPA", "INPB", "INPC", "INPD", "INPE", "INPF", "INPG",
-             "INPH", "INPI", "INPJ", "INPK", "INPL", "SDIS", "TSEL"),
-    "calcout": ("FLNK", "INPA", "INPB", "INPC", "INPD", "INPE", "INPF", "INPG",
-                "INPH", "INPI", "INPJ", "INPK", "INPL", "OUT", "SDIS", "TSEL"),
-    "compress": ("FLNK", "INP", "SDIS", "TSEL"),
-    "dfanout": ("DOL", "FLNK", "OUTA", "OUTB", "OUTC", "OUTD", "OUTE", "OUTF",
-                "OUTG", "OUTH", "SDIS", "SELL", "TSEL"),
-    "event": ("FLNK", "INP", "SDIS", "SIML", "SIOL", "TSEL"),
-    "fanout": ("FLNK", "LNK0", "LNK1", "LNK2", "LNK3", "LNK4", "LNK5", "LNK6",
-               "LNK7", "LNK8", "LNK9", "LNKA", "LNKB", "LNKC", "LNKD", "LNKE",
-               "LNKF", "SDIS", "SELL", "TSEL"),
-    "histogram": ("FLNK", "SDIS", "SIML", "SIOL", "SVL", "TSEL"),
-    "int64in": ("FLNK", "INP", "SDIS", "SIML", "SIOL", "TSEL"),
-    "int64out": ("DOL", "FLNK", "OUT", "SDIS", "SIML", "SIOL", "TSEL"),
-    "longin": ("FLNK", "INP", "SDIS", "SIML", "SIOL", "TSEL"),
-    "longout": ("DOL", "FLNK", "OUT", "SDIS", "SIML", "SIOL", "TSEL"),
-    "lsi": ("FLNK", "INP", "SDIS", "SIML", "SIOL", "TSEL"),
-    "lso": ("DOL", "FLNK", "OUT", "SDIS", "SIML", "SIOL", "TSEL"),
-    "mbbi": ("FLNK", "INP", "SDIS", "SIML", "SIOL", "TSEL"),
-    "mbbiDirect": ("FLNK", "INP", "SDIS", "SIML", "SIOL", "TSEL"),
-    "mbbo": ("DOL", "FLNK", "OUT", "SDIS", "SIML", "SIOL", "TSEL"),
-    "mbboDirect": ("DOL", "FLNK", "OUT", "SDIS", "SIML", "SIOL", "TSEL"),
-    "permissive": ("FLNK", "SDIS", "TSEL"),
-    "printf": ("FLNK", "INP0", "INP1", "INP2", "INP3", "INP4", "INP5", "INP6",
-               "INP7", "INP8", "INP9", "OUT", "SDIS", "TSEL"),
-    "sel": ("FLNK", "INPA", "INPB", "INPC", "INPD", "INPE", "INPF", "INPG",
-            "INPH", "INPI", "INPJ", "INPK", "INPL", "NVL", "SDIS", "TSEL"),
-    "seq": ("DOL0", "DOL1", "DOL2", "DOL3", "DOL4", "DOL5", "DOL6", "DOL7",
-            "DOL8", "DOL9", "DOLA", "DOLB", "DOLC", "DOLD", "DOLE", "DOLF",
-            "FLNK", "LNK0", "LNK1", "LNK2", "LNK3", "LNK4", "LNK5", "LNK6",
-            "LNK7", "LNK8", "LNK9", "LNKA", "LNKB", "LNKC", "LNKD", "LNKE",
-            "LNKF", "SDIS", "SELL", "TSEL"),
-    "state": ("FLNK", "SDIS", "TSEL"),
-    "stringin": ("FLNK", "INP", "SDIS", "SIML", "SIOL", "TSEL"),
-    "stringout": ("DOL", "FLNK", "OUT", "SDIS", "SIML", "SIOL", "TSEL"),
-    "sub": ("FLNK", "INPA", "INPB", "INPC", "INPD", "INPE", "INPF", "INPG",
-            "INPH", "INPI", "INPJ", "INPK", "INPL", "SDIS", "TSEL"),
-    "subArray": ("FLNK", "INP", "SDIS", "TSEL"),
-    "waveform": ("FLNK", "INP", "SDIS", "SIML", "SIOL", "TSEL")
-}
 
 
 @dataclass
@@ -780,12 +722,61 @@ class RecordType:
     info: Dict[str, str] = field(default_factory=dict)
     is_grecord: bool = False
 
+    def get_links_for_record(
+        self, record: RecordInstance
+    ) -> Generator[Tuple[RecordField, str, List[str]], None, None]:
+        """
+        Get all links - in, out, and forward links - for the given record.
+
+        Parameters
+        ----------
+        record : RecordInstance
+            Additional information, if the database definition wasn't loaded
+            with this instance.
+
+        Yields
+        ------
+        field : RecordField
+        link_text: str
+        link_info: str
+        """
+        if record.record_type != self.name:
+            raise ValueError("Record types do not match")
+
+        for field_type_info in self.get_fields_of_type(*LINK_TYPES):
+            field_instance = record.fields.get(field_type_info.name, None)
+            if field_instance and not isinstance(field_instance, PVAFieldReference):
+                try:
+                    link, info = get_link_information(field_instance.value)
+                except ValueError:
+                    continue
+                yield field_instance, link, info
+
+    def get_fields_of_type(self, *types: str) -> Generator[RecordTypeField, None, None]:
+        """Get all fields of the matching type(s)."""
+        for fld in self.fields.values():
+            if fld.type in types:
+                yield fld
+
+    def get_link_fields(
+        self,
+    ) -> Generator[Tuple[RecordTypeField, str, Tuple[str, ...]], None, None]:
+        """
+        Get all link fields - in, out, and forward links.
+
+        Yields
+        ------
+        field : RecordTypeField
+        """
+        yield from self.get_fields_of_type(*LINK_TYPES)
+
 
 @dataclass
 class RecordInstance:
     context: FullLoadContext
     name: str
     record_type: str
+    has_dbd_info: bool = False
     fields: Dict[str, AnyField] = field(default_factory=dict)
     info: Dict[StringWithContext, Any] = field(default_factory=dict)
     metadata: Dict[StringWithContext, Any] = field(default_factory=dict)
@@ -832,9 +823,12 @@ record("{{record_type}}", "{{name}}") {
 
     def get_links(
         self,
-    ) -> Generator[Tuple[RecordField, str, Tuple[str, ...]], None, None]:
+    ) -> Generator[Tuple[RecordField, str, List[str]], None, None]:
         """
-        Get all links.
+        Get all links - in, out, and forward links - for this record.
+
+        Requires that a dbd file was loaded when the record was created.
+        Alternatively, see :func:`RecordType.get_links_for_record`.
 
         Yields
         ------
@@ -848,34 +842,6 @@ record("{{record_type}}", "{{name}}") {
             except ValueError:
                 continue
             yield fld, link, info
-
-    def get_common_links(
-        self,
-    ) -> Generator[Tuple[RecordField, str, Tuple[str, ...]], None, None]:
-        """
-        Without using a database definition, try to find links.
-
-        This differs from ``get_links`` in that the other method requires
-        a dbd file to be loaded, whereas this will use a simple - but possibly
-        inaccurate - map of of record type to link fields.
-
-        Yields
-        ------
-        field : RecordField
-        link_text: str
-        link_info: str
-        """
-        if self.is_pva:
-            return
-
-        for name in LINK_FIELDS_BY_RECORD.get(self.record_type, COMMON_LINK_FIELDS):
-            fld = self.fields.get(name, None)
-            if fld is not None:
-                try:
-                    link, info = get_link_information(fld.value)
-                except ValueError:
-                    continue
-                yield fld, link, info
 
     def to_summary(self) -> RecordInstanceSummary:
         """Return a summarized version of the record instance."""
@@ -906,6 +872,7 @@ record("{{record_type}}", "{{name}}") {
             [alias for alias in other.aliases if alias not in self.aliases]
         )
 
+        self.has_dbd_info = self.has_dbd_info or other.has_dbd_info
         if self.record_type != other.record_type:
             return [
                 LinterError(

--- a/whatrecord/graph.py
+++ b/whatrecord/graph.py
@@ -588,22 +588,18 @@ class RecordLinkGraph(_GraphHelper):
         for li in find_record_links(
             self.database.records, self.starting_records, relations=self.relations
         ):
-            for (rec, field) in ((li.record1, li.field1), (li.record2, li.field2)):
-                if rec.name not in self.nodes:
-                    self.get_node(label=rec.name, text=field.name)
-
-            src = self.get_node(li.record1.name)
-            dest = self.get_node(li.record2.name)
+            src = self.get_node(li.record1.name, text=" ")
+            dest = self.get_node(li.record2.name, text=" ")
 
             for field, node in [(li.field1, src), (li.field2, dest)]:
                 if field.value or self.show_empty:
                     text_line = self.field_format.format(
                         field=field.name, value=field.value
                     )
-                    if node.text and text_line not in node.text:
-                        node.text = "\n".join((node.text, text_line))
-                    else:
+                    if not node.text.strip():
                         node.text = text_line
+                    elif text_line not in node.text:
+                        node.text = "\n".join((node.text, text_line))
 
             if li.field1.dtype == "DBF_INLINK":
                 src, dest = dest, src

--- a/whatrecord/tests/test_graph.py
+++ b/whatrecord/tests/test_graph.py
@@ -37,12 +37,15 @@ record({record_type}, "{record_name}") {{
     return db.records[record_name]
 
 
-def test_simple_graph():
+def test_simple_graph(dbd: Database):
     database = {
         "record_a": create_record("ai", "record_a", {"INP": "record_b CPP MS", "VAL": "10"}),
         "record_b": create_record("ao", "record_b", {"OUT": "record_c CA", "VAL": "20"}),
     }
-    relations = graph.build_database_relations(database)
+    relations = graph.build_database_relations(
+        database,
+        record_types=dbd.record_types,
+    )
     print(database["record_a"])
     assert relations["record_a"]["record_b"] == [
         (
@@ -81,7 +84,7 @@ def dbd():
     )
 
 
-def test_combine_relations():
+def test_combine_relations(dbd: Database):
     database_1 = {
         "record_a": create_record("ai", "record_a", {"INP": "record_b CPP MS", "VAL": "10"}),
         "record_b": create_record("ao", "record_b", {"OUT": "record_c CA", "VAL": "20"}),
@@ -91,12 +94,16 @@ def test_combine_relations():
         "record_d": create_record("ai", "record_d", {"INP": "", "VAL": "10"}),
         "record_e": create_record("ai", "record_e", {"INP": "record_a CP", "VAL": "10"}),
     }
-    relations = graph.build_database_relations(database_1)
+    relations = graph.build_database_relations(
+        database_1,
+        record_types=dbd.record_types,
+    )
     graph.combine_relations(
         relations,
         database_1,
         graph.build_database_relations(database_2),
         database_2,
+        record_types=dbd.record_types,
     )
 
     assert relations["record_a"]["record_b"] == [
@@ -245,6 +252,7 @@ def test_combine_with_alias(dbd: Database):
             "alias_a": "record_a",
             "alias_b": "record_b",
         },
+        record_types=dbd.record_types,
     )
 
     relations_2 = graph.build_database_relations(
@@ -254,6 +262,7 @@ def test_combine_with_alias(dbd: Database):
             "alias_d": "record_d",
             "alias_e": "record_e",
         },
+        record_types=dbd.record_types,
     )
 
     graph.combine_relations(
@@ -268,6 +277,7 @@ def test_combine_with_alias(dbd: Database):
             "alias_d": "record_d",
             "alias_e": "record_e",
         },
+        record_types=dbd.record_types,
     )
 
     assert relations["record_a"]["record_b"] == [

--- a/whatrecord/tests/test_v3_parsing.py
+++ b/whatrecord/tests/test_v3_parsing.py
@@ -307,3 +307,17 @@ record(ai, "rec:X") {
             message="Unquoted field value 'B'"
         )
     ]
+
+
+@pytest.mark.parametrize(
+    "version", [3, 4],
+)
+def test_load_vendored_database_smoke(version: int):
+    dbd = Database.from_vendored_dbd(version=version)
+    record_types = list(dbd.record_types.values())
+    assert len(record_types)
+    record = record_types[0]
+    if version == 3:
+        assert "v3_softIoc.dbd" in record.context[0].name
+    else:
+        assert "softIoc.dbd" in record.context[0].name


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Record link graphing needs some reworking, even after this gets completed
* I was hoping to get it done today, but ran out of time
* This is still probably in a better state than before, but I want to give it another look
* Test suite will fail until I get to fixing it

## Motivation and Context
* The actual first user of whatrecord after over a year of being released discovered it didn't quite work as advertised 😬  
* Excuse: `whatrecord graph` command-line worked differently than the originally included `st.cmd`-backed evaluator, which would auto-load and use the dbd where necessary

Closes #125 

## How Has This Been Tested?
Interactively, with a user-provided db file

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/5139267/167958757-a8cb789f-6ee8-4a05-bb21-391c1622bd0c.png)
