### PR TITLE
FIX: python 2 compatibility for old gdb

### DIFF
--- a/whatrecord/plugins/gdb_binary_info.py
+++ b/whatrecord/plugins/gdb_binary_info.py
@@ -183,7 +183,7 @@ except Exception as ex:
         "commands": {},
         "base_version": None,
         "variables": {},
-        "error": f"{type(ex).__name__}: {ex}",
+        "error": "{0}: {1}".format(type(ex).__name__, ex),
     }
 finally:
     if OLD_GDB:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
GDB EPICS binary information tool should support Python 2 syntax because psbuild and others have an ancient gdb version.

## Motivation and Context
Closes #129 

## How Has This Been Tested?
Briefly checked on 9.2 and 7.6.1:
```
GNU gdb (GDB) 9.2
Copyright (C) 2020 Free Software Foundation, Inc.
```

```
$ /usr/bin/gdb --version
GNU gdb (GDB) Red Hat Enterprise Linux 7.6.1-120.el7
Copyright (C) 2013 Free Software Foundation, Inc.
```
