### PR TITLE
FIX: ignore non str RecordField fields in `whatrecord graph`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,9 @@ import os
 import shutil
 import sys
 
+if sys.platform == "darwin":
+    os.environ.setdefault("MACOSX_DEPLOYMENT_TARGET", "10.9")
+
 if os.environ.get("CONDA_BUILD_STATE") == "RENDER":
     epicscorelibs = None
 else:

--- a/whatrecord/common.py
+++ b/whatrecord/common.py
@@ -596,7 +596,7 @@ ScriptPVRelations = Dict[
 
 def get_link_information(link_str: str) -> Tuple[str, List[str]]:
     """Get link information from a DBF_{IN,OUT,FWD}LINK value."""
-    if isinstance(link_str, dict):
+    if not isinstance(link_str, str):
         # Oh, PVA...
         raise ValueError("PVA links are TODO, sorry")
 
@@ -760,12 +760,16 @@ class RecordType:
 
         for field_type_info in self.get_fields_of_type(*LINK_TYPES):
             field_instance = record.fields.get(field_type_info.name, None)
-            if field_instance and not isinstance(field_instance, PVAFieldReference):
-                try:
-                    link, info = get_link_information(field_instance.value)
-                except ValueError:
-                    continue
-                yield field_instance, link, info
+            if field_instance is None:
+                continue
+            elif isinstance(field_instance, PVAFieldReference):
+                continue
+
+            try:
+                link, info = get_link_information(field_instance.value)
+            except ValueError:
+                continue
+            yield field_instance, link, info
 
     def get_fields_of_type(self, *types: str) -> Generator[RecordTypeField, None, None]:
         """Get all fields of the matching type(s)."""

--- a/whatrecord/common.py
+++ b/whatrecord/common.py
@@ -596,9 +596,13 @@ ScriptPVRelations = Dict[
 
 def get_link_information(link_str: str) -> Tuple[str, List[str]]:
     """Get link information from a DBF_{IN,OUT,FWD}LINK value."""
+    if isinstance(link_str, (dict, list)):
+        raise ValueError("JSON and PVAccess links are a TODO (sorry!)")
     if not isinstance(link_str, str):
-        # Oh, PVA...
-        raise ValueError("PVA links are TODO, sorry")
+        raise ValueError(
+            f"Unexpected and supported type for get_link_information: "
+            f"{type(link_str)}"
+        )
 
     if " " in link_str:
         # strip off PP/MS/etc (TODO might be useful later)

--- a/whatrecord/tests/test_graph.py
+++ b/whatrecord/tests/test_graph.py
@@ -340,3 +340,23 @@ def test_combine_with_alias(dbd: Database):
             ["CP"],
         ),
     ]
+
+
+def test_list_value_graph(dbd: Database):
+    database_1 = {
+        "record_a": create_record(
+            "ai",
+            "record_a",
+            {
+                # Note: field(INP, ["this is a long string array value"])
+                "INP": ("this is a long string array value",),
+                "VAL": "10",
+            },
+        ),
+    }
+
+    # Ensure this doesn't raise
+    graph.build_database_relations(
+        database_1,
+        record_types=dbd.record_types,
+    )

--- a/whatrecord/tests/test_pva_parsing.py
+++ b/whatrecord/tests/test_pva_parsing.py
@@ -6,7 +6,7 @@ import lark
 import pytest
 
 from ..common import LoadContext
-from ..db import Database, PVAFieldReference, RecordInstance
+from ..db import Database, PVAFieldReference, RecordField, RecordInstance
 
 
 def test_simple():
@@ -147,3 +147,17 @@ record(ai, "rec:X") {
 }
 """
         )
+
+
+def test_list_as_value():
+    db = Database.from_string(
+        """\
+record(ai, "rec:X") {
+    field(VAL, ["test value"])
+}
+""",
+        version=4,
+    )
+    val = db.records["rec:X"].fields["VAL"]
+    assert isinstance(val, RecordField)
+    assert val.value == ("test value",)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Ignore non str RecordField fields in `whatrecord graph`.

## Motivation and Context
* Experimenting with the `lsi` record
* To set it at startup, you need to use `field(INP, ["value"])` to indicate it's an array and not a link name (per tech talk)
* Graph will fail as it only checks for PVA field references (which are described as JSON objects / `dict` in the EPICS process database)

## How Has This Been Tested?
* Parsing test added in test suite
* Record relations checked to not fail in test suite when a field is a JSON value (i.e., non-str)

## Where Has This Been Documented?
PR text