### PR TITLE
REF: remove linterresults

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ version: ~> 1.0
 
 language: python
 os: linux
-dist: xenial
+dist: focal
 
 stages:
   - test

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,10 +48,11 @@ jobs:
         - python -m pip install .
         - python -m pip install --requirement dev-requirements.txt
       script:
-        - |
-          set -e
-          coverage run --concurrency=thread --parallel-mode -m pytest -vv
-          (coverage combine && coverage report | grep -v -e ' 0%') || true
+        - pytest -vv --cov=whatrecord/
+
+    - <<: *testpythonpip
+      name: "Python 3.10 - PIP"
+      python: "3.10"
 
     - &testpythonconda
       stage: test
@@ -88,7 +89,4 @@ jobs:
         - python -m pip install --requirement dev-requirements.txt
         - conda list
       script:
-        - |
-          set -e
-          coverage run --concurrency=thread --parallel-mode -m pytest -vv
-          (coverage combine && coverage report | grep -v -e ' 0%') || true
+        - pytest -vv --cov=whatrecord/

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,10 +1,10 @@
 # These are required for developing the package (running the tests, building
 # the documentation) but not necessarily required for _using_ it.
 codecov
-coverage
 flake8
 pytest
 pytest-aiohttp
+pytest-cov
 
 # docs-related dependencies:
 mkdocs

--- a/whatrecord/bin/graph.py
+++ b/whatrecord/bin/graph.py
@@ -11,12 +11,12 @@ import pathlib
 import re
 import shutil
 import tempfile
-from typing import List, Optional, Union
+from typing import List, Optional, Union, cast
 
 import graphviz as gv
 
 from ..common import AnyPath
-from ..db import Database, LinterResults
+from ..db import Database
 from ..graph import RecordLinkGraph, build_database_relations, graph_links
 from ..makefile import DependencyGroup, DependencyGroupGraph, Makefile
 from ..shell import LoadedIoc
@@ -132,7 +132,7 @@ def render_graph_to_file(
         shutil.copyfile(rendered_filename, filename)
 
 
-DatabaseItem = Union[LinterResults, LoadedIoc, Database]
+DatabaseItem = Union[LoadedIoc, Database]
 
 
 def _records_by_patterns(
@@ -185,7 +185,6 @@ def main(
 ):
     highlight = highlight or []
 
-    databases_only = len(filenames) > 1
     loaded_items = [
         parse_from_cli_args(
             filename=filename,
@@ -200,12 +199,8 @@ def main(
         for filename in filenames
     ]
 
-    databases_only = all(
-        isinstance(item, (LinterResults, LoadedIoc, Database))
-        for item in loaded_items
-    )
-
-    if databases_only:
+    if all(isinstance(item, DatabaseItem) for item in loaded_items):
+        loaded_items = cast(List[DatabaseItem], loaded_items)
         graph = get_database_graph(*loaded_items, highlight=highlight)
         if not graph.nodes:
             logger.warning(

--- a/whatrecord/bin/graph.py
+++ b/whatrecord/bin/graph.py
@@ -199,7 +199,7 @@ def main(
         for filename in filenames
     ]
 
-    if all(isinstance(item, DatabaseItem) for item in loaded_items):
+    if all(isinstance(item, (LoadedIoc, Database)) for item in loaded_items):
         loaded_items = cast(List[DatabaseItem], loaded_items)
         graph = get_database_graph(*loaded_items, highlight=highlight)
         if not graph.nodes:

--- a/whatrecord/dbtemplate.py
+++ b/whatrecord/dbtemplate.py
@@ -98,7 +98,7 @@ class Substitution:
 
         filename = pathlib.Path(filename)
         search_paths = search_paths or [filename.resolve().parent]
-        with open(self.filename, "rt") as fp:
+        with open(filename, "rt") as fp:
             return self.expand(fp.read(), search_paths=search_paths)
 
     @property

--- a/whatrecord/parse.py
+++ b/whatrecord/parse.py
@@ -9,7 +9,7 @@ from typing import Dict, Optional, Union
 
 from .access_security import AccessSecurityConfig
 from .common import AnyPath, FileFormat, IocMetadata
-from .db import Database, LinterResults
+from .db import Database
 from .dbtemplate import TemplateSubstitution
 from .gateway import PVList as GatewayPVList
 from .macro import MacroContext
@@ -25,7 +25,6 @@ ParseResult = Union[
     AccessSecurityConfig,
     Database,
     GatewayPVList,
-    LinterResults,
     LoadedIoc,
     SequencerProgram,
     StreamProtocol,
@@ -88,8 +87,8 @@ def parse(
             return Database.from_file(
                 filename, macro_context=macro_context, version=3 if v3 else 4
             )
-        return LinterResults.from_database_file(
-            db_filename=filename,
+        return Database.from_file(
+            filename,
             dbd=Database.from_file(dbd, version=3 if v3 else 4),
             macro_context=macro_context
         )

--- a/whatrecord/tests/test_v3_parsing.py
+++ b/whatrecord/tests/test_v3_parsing.py
@@ -5,8 +5,8 @@ import pytest
 
 from .. import Database
 from ..common import LoadContext
-from ..db import (DatabaseMenu, LinterResults, LinterWarning, RecordField,
-                  RecordInstance, RecordType, RecordTypeField)
+from ..db import (DatabaseMenu, LinterWarning, RecordField, RecordInstance,
+                  RecordType, RecordTypeField)
 
 v3_or_v4 = pytest.mark.parametrize("version", [3, 4])
 
@@ -291,7 +291,7 @@ alias("rec:X", "rec:Y")
 
 
 def test_unquoted_warning():
-    lint = LinterResults.from_database_string(
+    db = Database.from_string(
         """\
 record(ai, "rec:X") {
     field(A, "test")
@@ -300,7 +300,7 @@ record(ai, "rec:X") {
 """,
         version=3
     )
-    assert lint.warnings == [
+    assert db.lint.warnings == [
         LinterWarning(
             name="unquoted_field",
             line=3,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Remove `whatrecord.LinterResults`
* Wrap lint into `whatrecord.Database` `.lint` attribute, which is a `DatabaseLint` instance

## Motivation and Context
There are too many classes representing a `Database` in whatrecord; this removes one and wraps it into `Database.lint`

## How Has This Been Tested?
* Test suite

## TODO
These will happen in separate PRs:
- Server needs updating
- More lint checks should be added