### PR TITLE
FIX: forward link edges + allow for stdin usage in `whatrecord [parse|graph]`

### DIFF
--- a/whatrecord/graph.py
+++ b/whatrecord/graph.py
@@ -739,7 +739,7 @@ class RecordLinkGraph(_GraphHelper):
                         """
                     ).rstrip()
 
-            if li.field1.dtype == "DBF_INLINK":
+            if li.field1.dtype == "DBF_INLINK" or li.field2.dtype == "DBF_OUTLINK":
                 src, dest = dest, src
                 li.field1, li.field2 = li.field2, li.field1
 

--- a/whatrecord/graph.py
+++ b/whatrecord/graph.py
@@ -753,9 +753,24 @@ class RecordLinkGraph(_GraphHelper):
                         break
 
             if (src, dest) not in set(self.edge_pairs):
-                if "DBF_FWDLINK" in (li.field1.dtype, li.field2.dtype):
-                    edge_kw["taillabel"] = "FLNK"
-                    self.add_edge(src.label, dest.label, color="black", **edge_kw)
+                if li.field1.dtype == "DBF_FWDLINK":
+                    # edge_kw["taillabel"] = "FLNK"
+                    self.add_edge(
+                        src.label,
+                        dest.label,
+                        color="black",
+                        source_port=li.field1.name,
+                        **edge_kw
+                    )
+                elif li.field2.dtype == "DBF_FWDLINK":
+                    # edge_kw["taillabel"] = "FLNK"
+                    self.add_edge(
+                        dest.label,
+                        src.label,
+                        color="black",
+                        source_port=li.field2.name,
+                        **edge_kw
+                    )
                 else:
                     # edge_kw["taillabel"] = f"{li.field1.name}"
                     # edge_kw["headlabel"] = f"{li.field2.name}"

--- a/whatrecord/parse.py
+++ b/whatrecord/parse.py
@@ -76,15 +76,19 @@ def parse(
     standin_directories = standin_directories or {}
 
     if str(filename) == "-":
-        contents = sys.stdin.read()
-        filename = pathlib.Path("/dev/stdin")
-
         if format is None:
             options = [fmt.name for fmt in list(FileFormat)]
             raise ValueError(
                 f"Format must be specified when piping data from standard "
                 f"input.  Choose one of: {options}"
             )
+        if format == FileFormat.iocsh:
+            raise ValueError(
+                "IOC shell script parsing not supported through standard input"
+            )
+
+        contents = sys.stdin.read()
+        filename = pathlib.Path(sys.stdin.name)
     else:
         with open(filename, "rt") as fp:
             contents = fp.read()
@@ -112,11 +116,6 @@ def parse(
         )
 
     if format == FileFormat.iocsh:
-        if filename == pathlib.Path("/dev/stdin"):
-            raise ValueError(
-                "IOC shell script parsing not supported through standard input"
-            )
-
         md = IocMetadata.from_filename(
             filename,
             standin_directories=standin_directories,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Fix FLNK source ports and direction.

## Motivation and Context
Forward link edges were inaccurately drawn with graphviz, so this PR should fix them.

## Screenshots (if appropriate):
Looks correct now:
<img width="807" alt="image" src="https://user-images.githubusercontent.com/5139267/191697547-da1b4c90-b44b-4837-8b90-2b974711156d.png">
