### PR TITLE
REF/ENH: add settings to exclude all/certain env vars in serialization

### DIFF
--- a/whatrecord/macro.py
+++ b/whatrecord/macro.py
@@ -79,8 +79,8 @@ def should_serialize_key(key: str, value: str) -> bool:
     * WHATRECORD_MACRO_KEY_SKIP (str) - keys to skip, specified by regular
       expressions.  Should be valid Python syntax for a list of strings, as it
       will be handed to ``ast.literal_eval``.
-    * WHATRECORD_MACRO_NO_ENV (bool) - do not serialize *any* environment
-      variables if set to 1.
+    * WHATRECORD_MACRO_INCLUDE_ENV (bool) - serialize environment variables if
+      set to 1.
     * WHATRECORD_MACRO_VALUE_MAX_LENGTH (int) - maximum length of macro values
       to serialize. 0 to disable maximum length check.
 
@@ -99,9 +99,12 @@ def should_serialize_key(key: str, value: str) -> bool:
     if settings.MACRO_VALUE_MAX_LENGTH > 0:
         if len(value) > settings.MACRO_VALUE_MAX_LENGTH:
             return False
-    if settings.MACRO_NO_ENV and key in os.environ:
+
+    # Throw out environment variables if MACRO_INCLUDE_ENV is unset:
+    if not settings.MACRO_INCLUDE_ENV and key in os.environ:
         return False
-    # Bad key or one that matches regular expressions in RE_MACRO_KEY_SKIP#
+
+    # Bad key or one that matches regular expressions in RE_MACRO_KEY_SKIP
     # (by way of 'WHATRECORD_MACRO_KEY_SKIP')
     if not key:
         return False

--- a/whatrecord/macro.py
+++ b/whatrecord/macro.py
@@ -1,8 +1,13 @@
+import ast
 import dataclasses
-from typing import Any, Dict
+import os
+import re
+from typing import Any, Dict, Optional
 
 import apischema
 from epicsmacrolib import MacroContext
+
+from . import settings
 
 
 def macros_from_string(
@@ -40,13 +45,82 @@ class _SerializedMacroContext:
     macros: Dict[str, str]
 
 
+RE_MACRO_KEY_SKIP = []
+
+# This becomes more of a concern when run on CI.
+# Consider tweaking this for your purposes in MACRO_KEY_SKIP or
+# setting MACRO_NO_ENV for CI jobs.
+MACRO_KEY_SKIP_DEFAULT = [
+    ".*TOKEN.*",
+    ".*SECRET.*",
+    ".*SSH.*",
+    ".*GITHUB.*",
+]
+
+
+def set_serialization_settings(skip: Optional[str] = settings.MACRO_KEY_SKIP):
+    """Update macro serialization settings."""
+    global RE_MACRO_KEY_SKIP
+    if skip:
+        skip_regex = ast.literal_eval(skip)
+    else:
+        skip_regex = MACRO_KEY_SKIP_DEFAULT
+    RE_MACRO_KEY_SKIP = [re.compile(regex) for regex in skip_regex]
+
+
+set_serialization_settings()
+
+
+def should_serialize_key(key: str, value: str) -> bool:
+    """
+    Should ``key`` be serialized when saving macros?
+
+    Settings used:
+    * WHATRECORD_MACRO_KEY_SKIP (str) - keys to skip, specified by regular
+      expressions.  Should be valid Python syntax for a list of strings, as it
+      will be handed to ``ast.literal_eval``.
+    * WHATRECORD_MACRO_NO_ENV (bool) - do not serialize *any* environment
+      variables if set to 1.
+    * WHATRECORD_MACRO_VALUE_MAX_LENGTH (int) - maximum length of macro values
+      to serialize. 0 to disable maximum length check.
+
+    Parameters
+    ----------
+    key : str
+        The macro/environment variable name.
+    value : str
+        The value associated with the macro.
+
+    Returns
+    -------
+    bool
+    """
+    # Above the maximum length threshold -> skip
+    if settings.MACRO_VALUE_MAX_LENGTH > 0:
+        if len(value) > settings.MACRO_VALUE_MAX_LENGTH:
+            return False
+    if settings.MACRO_NO_ENV and key in os.environ:
+        return False
+    # Bad key or one that matches regular expressions in RE_MACRO_KEY_SKIP#
+    # (by way of 'WHATRECORD_MACRO_KEY_SKIP')
+    if not key:
+        return False
+    return not any(regex.fullmatch(key) for regex in RE_MACRO_KEY_SKIP)
+
+
 @apischema.serializer
 def _serialize_macro_context(ctx: MacroContext) -> Dict[str, Any]:
+    macros = {
+        key: value
+        for key, value in ctx.items()
+        if should_serialize_key(key, value)
+    }
+
     return apischema.serialize(
         _SerializedMacroContext(
             show_warnings=ctx.show_warnings,
             string_encoding=ctx.string_encoding,
-            macros=dict(ctx),
+            macros=macros,
         )
     )
 

--- a/whatrecord/settings.py
+++ b/whatrecord/settings.py
@@ -2,15 +2,22 @@ import os
 
 _true_values = {"1", "y", "yes", "true"}
 
-MAX_RECORD_LENGTH = int(os.environ.get("EPICS_MAX_RECORD_LENGTH", "60"))
-EPICS_SITE_TOP = os.environ.get("EPICS_SITE_TOP", "/reg/g/pcds/epics")
+# Maximum number of records to return in a single query for the frontend:
 MAX_RECORDS = int(os.environ.get("WHATRECORD_MAX_RECORDS", 200))
+# Path to the gdb binary to use for symbol introspection:
 GDB_PATH = os.environ.get("WHATRECORD_GDB_PATH", "gdb")
+# A path to cache parsed and serialized IOC information and other (e.g., gdb
+# binary information):
 CACHE_PATH = os.environ.get("WHATRECORD_CACHE_PATH", "")
+# The default epics-base version to assume, where not specified otherwise.
 DEFAULT_BASE_VERSION = os.environ.get("WHATRECORD_BASE_VERSION", "3.15")
+# The server host to use (for the client)
 WHATREC_SERVER = os.environ.get("WHATRECORD_SERVER", "http://localhost:8898/")
+# List of plugins to enable.
 PLUGINS = os.environ.get("WHATRECORD_PLUGINS", "happi twincat_pytmc netconfig epicsarch").split(" ")
+# Period, in seconds, to scan for updated IOCs or files
 SERVER_SCAN_PERIOD = int(os.environ.get("WHATRECORD_SERVER_SCAN_PERIOD", "600"))
+# Period, in seconds, to reload autosave .sav files
 AUTOSAVE_RELOAD_PERIOD = int(os.environ.get("WHATRECORD_AUTOSAVE_RELOAD_PERIOD", "60"))
 
 # WHATRECORD_OUTPUT_INDENT (int) - indentation in spaces when rendering output.
@@ -20,9 +27,12 @@ INDENT = int(os.environ.get("WHATRECORD_OUTPUT_INDENT", "4"))
 # expressions.  Should be valid Python syntax for a list of strings, as it
 # will be handed to ``ast.literal_eval``.
 MACRO_KEY_SKIP = os.environ.get("WHATRECORD_MACRO_KEY_SKIP", "")
-# WHATRECORD_MACRO_NO_ENV (bool) - do not serialize *any* environment
-# variables if set to 1.
-MACRO_NO_ENV = os.environ.get("WHATRECORD_MACRO_NO_ENV", "true").lower() in _true_values
+# WHATRECORD_MACRO_INCLUDE_ENV (bool) - serialize environment variables if set
+# to 1.
+MACRO_INCLUDE_ENV = os.environ.get("WHATRECORD_MACRO_INCLUDE_ENV", "true").lower() in _true_values
 # WHATRECORD_MACRO_VALUE_MAX_LENGTH (int) - maximum length of macro values to
 # serialize. 0 to disable maximum length check.
 MACRO_VALUE_MAX_LENGTH = int(os.environ.get("WHATRECORD_MACRO_VALUE_MAX_LENGTH", 1024))
+
+# A SLAC-specific setting (other facilities may ignore this):
+EPICS_SITE_TOP = os.environ.get("EPICS_SITE_TOP", "/reg/g/pcds/epics")

--- a/whatrecord/settings.py
+++ b/whatrecord/settings.py
@@ -1,5 +1,7 @@
 import os
 
+_true_values = {"1", "y", "yes", "true"}
+
 MAX_RECORD_LENGTH = int(os.environ.get("EPICS_MAX_RECORD_LENGTH", "60"))
 EPICS_SITE_TOP = os.environ.get("EPICS_SITE_TOP", "/reg/g/pcds/epics")
 MAX_RECORDS = int(os.environ.get("WHATRECORD_MAX_RECORDS", 200))
@@ -10,4 +12,17 @@ WHATREC_SERVER = os.environ.get("WHATRECORD_SERVER", "http://localhost:8898/")
 PLUGINS = os.environ.get("WHATRECORD_PLUGINS", "happi twincat_pytmc netconfig epicsarch").split(" ")
 SERVER_SCAN_PERIOD = int(os.environ.get("WHATRECORD_SERVER_SCAN_PERIOD", "600"))
 AUTOSAVE_RELOAD_PERIOD = int(os.environ.get("WHATRECORD_AUTOSAVE_RELOAD_PERIOD", "60"))
+
+# WHATRECORD_OUTPUT_INDENT (int) - indentation in spaces when rendering output.
 INDENT = int(os.environ.get("WHATRECORD_OUTPUT_INDENT", "4"))
+
+# WHATRECORD_MACRO_KEY_SKIP (str) - keys to skip, specified by regular
+# expressions.  Should be valid Python syntax for a list of strings, as it
+# will be handed to ``ast.literal_eval``.
+MACRO_KEY_SKIP = os.environ.get("WHATRECORD_MACRO_KEY_SKIP", "")
+# WHATRECORD_MACRO_NO_ENV (bool) - do not serialize *any* environment
+# variables if set to 1.
+MACRO_NO_ENV = os.environ.get("WHATRECORD_MACRO_NO_ENV", "true").lower() in _true_values
+# WHATRECORD_MACRO_VALUE_MAX_LENGTH (int) - maximum length of macro values to
+# serialize. 0 to disable maximum length check.
+MACRO_VALUE_MAX_LENGTH = int(os.environ.get("WHATRECORD_MACRO_VALUE_MAX_LENGTH", 1024))

--- a/whatrecord/tests/test_macro.py
+++ b/whatrecord/tests/test_macro.py
@@ -7,9 +7,10 @@ from .. import settings
 from ..macro import MacroContext
 
 
-def test_skip_keys():
+def test_skip_keys(monkeypatch):
     include_key = "_WR_TEST_INCLUDED"
     exclude_key = "_WR_TEST_TOKEN"
+    monkeypatch.setattr(settings, "MACRO_INCLUDE_ENV", True)
     try:
         os.environ[exclude_key] = ""
         os.environ[include_key] = ""
@@ -23,9 +24,10 @@ def test_skip_keys():
     assert include_key in keys
 
 
-def test_skip_long_values():
+def test_skip_long_values(monkeypatch):
     include_key = "_WR_TEST_INCLUDED"
     exclude_key = "_WR_TEST_EXCLUDED"
+    monkeypatch.setattr(settings, "MACRO_INCLUDE_ENV", True)
     try:
         os.environ[exclude_key] = "a" * (settings.MACRO_VALUE_MAX_LENGTH + 1)
         os.environ[include_key] = "a" * (settings.MACRO_VALUE_MAX_LENGTH - 2)
@@ -39,13 +41,13 @@ def test_skip_long_values():
     assert include_key in keys
 
 
-@pytest.mark.parametrize("exclude", [False, True])
-def test_env_include_exclude(monkeypatch, exclude: bool):
-    monkeypatch.setattr(settings, "MACRO_NO_ENV", exclude)
+@pytest.mark.parametrize("include", [False, True])
+def test_env_include_exclude(monkeypatch, include: bool):
+    monkeypatch.setattr(settings, "MACRO_INCLUDE_ENV", include)
     ctx = MacroContext(use_environment=True)
     keys = set(apischema.serialize(MacroContext, ctx)["macros"])
 
-    if exclude:
+    if not include:
         assert set(keys) == set()
     else:
         assert 0 < len(set(keys)) <= len(os.environ)

--- a/whatrecord/tests/test_macro.py
+++ b/whatrecord/tests/test_macro.py
@@ -1,0 +1,51 @@
+import os
+
+import apischema
+import pytest
+
+from .. import settings
+from ..macro import MacroContext
+
+
+def test_skip_keys():
+    include_key = "_WR_TEST_INCLUDED"
+    exclude_key = "_WR_TEST_TOKEN"
+    try:
+        os.environ[exclude_key] = ""
+        os.environ[include_key] = ""
+        ctx = MacroContext(use_environment=True)
+        keys = list(apischema.serialize(MacroContext, ctx)["macros"])
+    finally:
+        os.environ.pop(include_key, None)
+        os.environ.pop(exclude_key, None)
+
+    assert exclude_key not in keys
+    assert include_key in keys
+
+
+def test_skip_long_values():
+    include_key = "_WR_TEST_INCLUDED"
+    exclude_key = "_WR_TEST_EXCLUDED"
+    try:
+        os.environ[exclude_key] = "a" * (settings.MACRO_VALUE_MAX_LENGTH + 1)
+        os.environ[include_key] = "a" * (settings.MACRO_VALUE_MAX_LENGTH - 2)
+        ctx = MacroContext(use_environment=True)
+        keys = list(apischema.serialize(MacroContext, ctx)["macros"])
+    finally:
+        os.environ.pop(include_key, None)
+        os.environ.pop(exclude_key, None)
+
+    assert exclude_key not in keys
+    assert include_key in keys
+
+
+@pytest.mark.parametrize("exclude", [False, True])
+def test_env_include_exclude(monkeypatch, exclude: bool):
+    monkeypatch.setattr(settings, "MACRO_NO_ENV", exclude)
+    ctx = MacroContext(use_environment=True)
+    keys = set(apischema.serialize(MacroContext, ctx)["macros"])
+
+    if exclude:
+        assert set(keys) == set()
+    else:
+        assert 0 < len(set(keys)) <= len(os.environ)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* pcds-ci is failing due to long environment variable values https://app.travis-ci.com/github/pcdshub/pcds-envs/jobs/586389673#L9085
* This assertion was present largely for testing but also to let users know there was a weird limit present in the original source code but they could work around it with a different call (a bad choice in retrospect)
* The appropriate handling of "too long values" is to pass them to macro lib anyway, which clips them at the provided buffer length

## Motivation and Context
* CI failures

## How Has This Been Tested?
* Additional test for macro context serialization

## Where Has This Been Documented?
This PR
