### PR TITLE
TST: mark test_gdb_info as xfail

### DIFF
--- a/whatrecord/tests/test_gdb_integration.py
+++ b/whatrecord/tests/test_gdb_integration.py
@@ -29,6 +29,7 @@ softioc_unavailable_skip = pytest.mark.skipif(
 )
 
 
+@pytest.mark.xfail(reason="Makes too many SLAC/LCLS/PCDS/ECS assumptions.")
 @platform_skip
 @gdb_unavailable_skip
 @softioc_unavailable_skip


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Marks test_gdb_info as xfail

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #147, but probably does not close it.

This test makes many assumptions specific to our deployment. In general, it's hard to tell if the configuration is correct, so for now it is more practical to mark it as xfail.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running the tests on CI

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
N/A

<!--
## Screenshots (if appropriate):
-->
