### PR TITLE
CI: check if secrets inherit works for pypi upload

### DIFF
--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   standard:
     uses: pcdshub/pcds-ci-helpers/.github/workflows/python-standard.yml@master
+    secrets: inherit
     with:
       # The workflow needs to know the package name.  This can be determined
       # automatically if the repository name is the same as the import name.
@@ -28,4 +29,3 @@ jobs:
       docs-system-packages: ""
       # Set if using setuptools-scm for the conda-build workflow
       use-setuptools-scm: true
-    secrets: inherit

--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -28,3 +28,4 @@ jobs:
       docs-system-packages: ""
       # Set if using setuptools-scm for the conda-build workflow
       use-setuptools-scm: true
+    secrets: inherit


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
https://docs.github.com/en/actions/using-workflows/reusing-workflows#passing-inputs-and-secrets-to-a-reusable-workflow
The github docs example is:
```
jobs:
  call-workflow-passing-data:
    uses: octo-org/example-repo/.github/workflows/reusable-workflow.yml@main
    with:
      config-path: .github/labeler.yml
    secrets: inherit
```
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
pypi upload fails on auth
