### PR TITLE
BLD: recipe test-requires, not test-requirements

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
   - python-graphviz <0.18
 
 test:
-  requirements:
+  requires:
     - codecov
     - flake8
     - happi


### PR DESCRIPTION
## Description
Conda recipe needs test-requires, not test-requirements

## Motivation and Context
Ran into this looking at lucid

## How Has This Been Tested?
The test suite should now have all the necessary test packages... though tests here look rough

## Where Has This Been Documented?
this PR