### PR TITLE
ENH: add --disable-macros + passthrough context

### DIFF
--- a/whatrecord/bin/parse.py
+++ b/whatrecord/bin/parse.py
@@ -2,6 +2,9 @@
 "whatrecord parse" is used to parse and interpret any of whatrecord's supported
 file formats, dumping the results to the console (standard output) in JSON
 format, by default.
+
+Unless ``--disable-macros`` is specified, all text will go through the macro
+context as if the files were being loaded in an IOC shell.
 """
 
 import argparse
@@ -68,6 +71,12 @@ def build_arg_parser(parser=None):
     )
 
     parser.add_argument(
+        "--disable-macros",
+        action="store_true",
+        help="Disable macro handling, leaving unexpanded macros in the output."
+    )
+
+    parser.add_argument(
         "-o", "--output",
         type=str,
         required=False,
@@ -105,6 +114,7 @@ def parse_from_cli_args(
     dbd: Optional[str] = None,
     standin_directory: Optional[List[str]] = None,
     macros: Optional[str] = None,
+    disable_macros: bool = False,
     use_gdb: bool = False,
     format: Optional[str] = None,
     expand: bool = False,
@@ -115,6 +125,9 @@ def parse_from_cli_args(
 
     This variant uses the raw CLI arguments, mapping them on to those that
     `parse` expects.  For programmatic usage, please use ``parse()`` directly.
+
+    Unless ``disable_macros`` is set, all text will go through the macro
+    context as if the files were being loaded in an IOC shell.
 
     Parameters
     ----------
@@ -128,7 +141,11 @@ def parse_from_cli_args(
         A list of substitute directories of the form ``DirectoryA=DirectoryB``.
 
     macros : str, optional
-        Macro string to use when parsing the file.
+        Macro string to use when parsing the file.  Ignored if
+        ``disable_macros`` is set.
+
+    disable_macros : bool, optional
+        Disable macro handling, leaving unexpanded macros in the output.
 
     expand : bool, optional
         Expand a substitutions file.
@@ -163,6 +180,7 @@ def parse_from_cli_args(
         dbd=dbd,
         standin_directories=standin_directories,
         macros=macros,
+        disable_macros=disable_macros,
         use_gdb=use_gdb,
         format=format,
         expand=expand,
@@ -178,6 +196,7 @@ def main(
     output_format: str = "json",
     output: Optional[str] = None,
     macros: Optional[str] = None,
+    disable_macros: bool = False,
     use_gdb: bool = False,
     expand: bool = False,
     v3: bool = False,
@@ -187,6 +206,7 @@ def main(
         dbd=dbd,
         standin_directory=standin_directory,
         macros=macros,
+        disable_macros=disable_macros,
         use_gdb=use_gdb,
         format=input_format,
         expand=expand,

--- a/whatrecord/parse.py
+++ b/whatrecord/parse.py
@@ -13,7 +13,7 @@ from .common import AnyPath, FileFormat, IocMetadata
 from .db import Database
 from .dbtemplate import TemplateSubstitution
 from .gateway import PVList as GatewayPVList
-from .macro import MacroContext
+from .macro import MacroContext, PassthroughMacroContext
 from .makefile import Makefile
 from .shell import LoadedIoc
 from .snl import SequencerProgram
@@ -39,6 +39,7 @@ def parse(
     dbd: Optional[str] = None,
     standin_directories: Optional[Dict[str, str]] = None,
     macros: Optional[str] = None,
+    disable_macros: bool = False,
     use_gdb: bool = False,
     format: Optional[FileFormat] = None,
     expand: bool = False,
@@ -66,6 +67,9 @@ def parse(
 
     macros : str, optional
         Macro string to use when parsing the file.
+
+    disable_macros : bool, optional
+        Disable macro handling, leaving unexpanded macros in the output.
 
     expand : bool, optional
         Expand a substitutions file.
@@ -95,7 +99,10 @@ def parse(
         filename = pathlib.Path(filename)
 
     # The shared macro context - used in different ways below:
-    macro_context = MacroContext(macro_string=macros or "")
+    if disable_macros:
+        macro_context = PassthroughMacroContext()
+    else:
+        macro_context = MacroContext(macro_string=macros or "")
 
     if format is None:
         format = FileFormat.from_filename(filename)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Add `--disable-macros` to `whatrecord parse`
   * For input formats where this is possible - such as database files - macros will remain untouched/unexpanded/uninterpolated in the output format.
   * That is to say, `field(DESC, "$(ABC)")` will remain as-is instead of `field(DESC, "value of abc")`
* Add `PassthroughMacroContext` which acts as a no-operation macro context but still supports all methods

## Motivation and Context
Closes #164 

`whatrecord` was built around the idea of "parse files as if the IOC shell were reading them".
That means that it aims to expand (interpolate) macros in files according to the EPICS environment and fall back to the shell environment variables (at least in certain scenarios) for each file that gets parsed.

## How Has This Been Tested?
* A bit locally with some database files
* Lazily in the test suite

## Where Has This Been Documented?
* Issue and PR

## Screenshots (if appropriate):
```
$ python -m whatrecord parse --disable-macros pu610k.db  |grep -e "\\$" | head
        "# Assume $(BASE) is the base PV, $(CHAN) is the channel number/name, $(PORT) is",
        "# the asyn port, and $(NAME) is the user-friendly name.",
        "#    field(FLNK, \"$(BASE):$(CHAN):REINIT\")",
        "$(BASE):$(CHAN):NAME": {
            "name": "$(BASE):$(CHAN):NAME",
                    "value": "$(NAME)",
```