### PR TITLE
TST: add missing dependency that reveals failing tests from pcds-envs

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -30,6 +30,7 @@ requirements:
 
 test:
   requires:
+    - blark
     - codecov
     - flake8
     - happi

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,6 +7,7 @@ pytest-aiohttp
 pytest-cov
 
 # plugin dependencies
+blark
 happi
 python-ldap
 pytmc


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add `blark` as a dev/test dependency, in an attempt to reveal a test that fails on pcds-envs but doesn't run at all in the test suite here.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In pcds-envs on the weekly build, whatrecord was failing with this message:
```
_________________________ test_serialize[PlcMetadata] __________________________

cls = <class 'whatrecord.plugins.twincat_pytmc.PlcMetadata'>

    @all_dataclasses
    def test_serialize(cls):
>       instance = try_to_instantiate(cls)

whatrecord/tests/test_serialization.py:151: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
whatrecord/tests/test_serialization.py:123: in try_to_instantiate
    type_hints = apischema.utils.get_type_hints(cls)
/home/runner/miniconda/envs/pcds-test/lib/python3.9/typing.py:1459: in get_type_hints
    value = _eval_type(value, base_globals, localns)
/home/runner/miniconda/envs/pcds-test/lib/python3.9/typing.py:292: in _eval_type
    return t._evaluate(globalns, localns, recursive_guard)
/home/runner/miniconda/envs/pcds-test/lib/python3.9/typing.py:554: in _evaluate
    eval(self.__forward_code__, globalns, localns),
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   ???
E   AttributeError: module 'blark.dependency_store' has no attribute 'ResolvedDependency'
```

I checked this repo and found that this test never gets run, and I think it's because there's an import error raised here: https://github.com/pcdshub/whatrecord/blob/16a9903c34e072ee7b6a87519f21d5057f5720b0/whatrecord/tests/test_serialization.py#L57 in importing whatrecord.plugins.twincat_pytmc here: https://github.com/pcdshub/whatrecord/blob/16a9903c34e072ee7b6a87519f21d5057f5720b0/whatrecord/plugins/twincat_pytmc.py#L28

Which is because `blark` isn't installed in the during the test suite.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
n/a, I just want to see if the test that fails on pcds-envs also fails on the base whatrecord repo
it's good to catch these earlier and I think all tests being run is the desired behavior

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
n/a

<!--
## Screenshots (if appropriate):
-->
