### PR TITLE
FIX/ENH: a few more fixes for cached/offline mode + plugin only mode

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,10 +11,12 @@
   },
   "dependencies": {
     "@types/d3-graphviz": "^2.6.7",
-    "axios": "^1.4.0",
+    "@types/pako": "^2.0.0",
+    "axios": "^1.5.0",
     "d3-graphviz": "^5.1.0",
     "d3-selection": "^3.0.0",
     "es6-promise": "^4.2.8",
+    "pako": "^2.1.0",
     "pinia": "^2.1.6",
     "primeflex": "^3.3.1",
     "primeicons": "^6.0.1",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -5,7 +5,7 @@
 
 <script lang="ts">
 import TabMenu from "primevue/tabmenu";
-import { plugins } from "./settings.ts";
+import { plugins, plugins_only_mode } from "./settings.ts";
 
 export default {
   name: "App",
@@ -13,15 +13,24 @@ export default {
     TabMenu,
   },
   data() {
-    let tab_menu_items = [
-      { label: "Records", icon: "pi pi-fw pi-tags", to: { name: "whatrec" } },
-      { label: "IOCs", icon: "pi pi-fw pi-sitemap", to: { name: "iocs" } },
-      {
+    let tab_menu_items = [];
+    if (!plugins_only_mode) {
+      tab_menu_items.push({
+        label: "Records",
+        icon: "pi pi-fw pi-tags",
+        to: { name: "whatrec" },
+      });
+      tab_menu_items.push({
+        label: "IOCs",
+        icon: "pi pi-fw pi-sitemap",
+        to: { name: "iocs" },
+      });
+      tab_menu_items.push({
         label: "PV Map",
         icon: "pi pi-fw pi-compass",
         to: { name: "pv-relations" },
-      },
-    ];
+      });
+    }
     for (const plugin of plugins) {
       tab_menu_items.push({
         label: plugin.label,
@@ -34,11 +43,13 @@ export default {
       icon: "pi pi-fw pi-shield",
       to: { name: "gateway" },
     });
-    tab_menu_items.push({
-      label: "Duplicates",
-      icon: "pi pi-pause",
-      to: { name: "duplicates" },
-    });
+    if (!plugins_only_mode) {
+      tab_menu_items.push({
+        label: "Duplicates",
+        icon: "pi pi-pause",
+        to: { name: "duplicates" },
+      });
+    }
     tab_menu_items.push({
       label: "Logs",
       icon: "pi pi-fw pi-list",

--- a/frontend/src/components/epics-format-record.vue
+++ b/frontend/src/components/epics-format-record.vue
@@ -36,7 +36,7 @@
       <router-link
         :to="{
           name: 'whatrec',
-          query: { pattern: pvagroup, record: pvagroup, use_regex: 'false' },
+          query: { pattern: pvagroup, record: pvagroup, regex: 'false' },
         }"
       >
         {{ pvagroup }}
@@ -67,7 +67,7 @@
             query: {
               pattern: field.record_name,
               record: field.record_name,
-              use_regex: 'false',
+              regex: 'false',
             },
           }"
           :title="JSON.stringify(field.metadata, null, 2)"

--- a/frontend/src/components/gateway-matches.vue
+++ b/frontend/src/components/gateway-matches.vue
@@ -20,7 +20,7 @@
               query: {
                 pattern: match.rule.pattern,
                 record: [],
-                use_regex: 'true',
+                regex: 'true',
               },
             }"
           >

--- a/frontend/src/components/recordinfo.vue
+++ b/frontend/src/components/recordinfo.vue
@@ -47,16 +47,14 @@
   </template>
 
   <template v-if="streamdevice_metadata">
-    <details>
+    <details class="streamdevice">
       <summary>
-        StreamDevice protocol (
-        <span class="monospace">
-          {{ streamdevice_metadata.protocol_file }} </span
-        >,
-        <span class="monospace">
-          "{{ streamdevice_metadata.protocol_name }}"
-        </span>
-        )
+        StreamDevice protocol
+        <script-context-link
+          :context="streamdevice_metadata.context"
+          :short="2"
+          prefix=""
+        />
       </summary>
       <dictionary-table
         :dict="streamdevice_metadata as any"
@@ -422,5 +420,9 @@ iframe {
   width: 100%;
   min-width: 50%;
   min-height: 50%;
+}
+
+.streamdevice .context {
+  display: inline;
 }
 </style>

--- a/frontend/src/components/recordinfo.vue
+++ b/frontend/src/components/recordinfo.vue
@@ -289,18 +289,6 @@ export default {
       }
       return url + this.record.name;
     },
-    graph_link() {
-      if (!this.store.is_online) {
-        return null;
-      }
-      return `/api/pv/graph?pv=${this.whatrec.name}&format=svg`;
-    },
-    script_graph_link() {
-      if (!this.store.is_online) {
-        return null;
-      }
-      return `/api/pv/script-graph?pv=${this.whatrec.name}&format=svg`;
-    },
     available_protocols() {
       let protocols = [];
       if (this.record != null) {
@@ -377,6 +365,8 @@ export default {
       const link_tab = this.$refs.link_tab as HTMLElement | null;
       if (!graph_div || !link_tab) {
         console.error("What happened? No graph or tab?");
+        this.pv_graph_dot_source = "digraph { unknown error }";
+        this.show_graph = false;
         return;
       }
       this.graph_width = graph_div.clientWidth || window.innerWidth * 0.75;

--- a/frontend/src/components/recordinfo.vue
+++ b/frontend/src/components/recordinfo.vue
@@ -271,7 +271,7 @@ export default {
           instance: this.record,
           plugin_matches: get_plugin_matches(this.record.metadata),
         });
-        console.log("matches", result);
+        console.debug("Found match:", result);
       }
       if (this.pva_group != null) {
         result.push({

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -28,16 +28,6 @@ let routes: RouteRecordRaw[] = [
     redirect: "/whatrec",
   },
   {
-    name: "whatrec",
-    path: "/whatrec",
-    component: WhatRec,
-    props: (route) => ({
-      pattern: route.query.pattern ?? "*",
-      use_regex: route.query.regex === "true",
-      record: nullable_string_to_array(route.query.record),
-    }),
-  },
-  {
     name: "file",
     path: "/file",
     component: ScriptView,
@@ -46,7 +36,21 @@ let routes: RouteRecordRaw[] = [
       line: route.query.line ? parseInt(route.query.line.toString()) : 0,
     }),
   },
-  {
+];
+
+if (true) {
+  routes.push({
+    name: "whatrec",
+    path: "/whatrec",
+    component: WhatRec,
+    props: (route) => ({
+      pattern: route.query.pattern ?? "*",
+      use_regex: route.query.regex === "true",
+      record: nullable_string_to_array(route.query.record),
+    }),
+  });
+
+  routes.push({
     name: "iocs",
     path: "/iocs/",
     component: IocView,
@@ -55,13 +59,20 @@ let routes: RouteRecordRaw[] = [
       ioc_filter: route.query.ioc_filter ?? "",
       record_filter: route.query.record_filter ?? "",
     }),
-  },
-  {
+  });
+
+  routes.push({
     name: "pv-relations",
     path: "/pv-relations",
     component: PVRelationsView,
-  },
-];
+  });
+
+  routes.push({
+    name: "duplicates",
+    path: "/duplicates",
+    component: DuplicateView,
+  });
+}
 
 if (happi_enabled) {
   routes.push({
@@ -109,12 +120,6 @@ if (epicsarch_enabled) {
 }
 
 routes.push({
-  name: "duplicates",
-  path: "/duplicates",
-  component: DuplicateView,
-});
-
-routes.push({
   name: "logs",
   path: "/logs",
   component: ServerLogView,
@@ -127,7 +132,7 @@ routes.push({
 });
 
 export const router = VueRouter.createRouter({
-  history: VueRouter.createWebHistory(),
+  history: VueRouter.createWebHashHistory(import.meta.env.BASE_URL),
   routes: routes,
   scrollBehavior() {
     const app = document.getElementById("app");

--- a/frontend/src/settings.ts
+++ b/frontend/src/settings.ts
@@ -1,6 +1,7 @@
 export const enabled_plugins = (
   import.meta.env.WHATRECORD_PLUGINS || "happi twincat_pytmc netconfig"
 ).split(" ");
+export const plugins_only_mode = import.meta.env.WHATRECORD_PLUGINS_ONLY == "1";
 export const happi_enabled = enabled_plugins.indexOf("happi") >= 0;
 export const netconfig_enabled = enabled_plugins.indexOf("netconfig") >= 0;
 export const twincat_pytmc_enabled =

--- a/frontend/src/stores/api.ts
+++ b/frontend/src/stores/api.ts
@@ -443,5 +443,11 @@ export const api_server_store = defineStore("api-server", {
       }
       return matches;
     },
+    async get_server_logs(): Promise<string[]> {
+      const response = await this.run_query<string[]>("/api/logs/get", {
+        params: {},
+      });
+      return response?.data ?? ["(Error loading logs)"];
+    },
   },
 });

--- a/frontend/src/stores/cached.ts
+++ b/frontend/src/stores/cached.ts
@@ -27,7 +27,7 @@ export const cached_local_store = defineStore("cached", {
       file_info: {} as Record<string, FileInfo>,
       gateway_info: null as GatewaySettings | null,
       glob_to_pvs: {} as Record<string, string[]>,
-      ioc_info: [] as IocMetadata[],
+      ioc_info: null as IocMetadata[] | null,
       ioc_to_records: {} as Record<string, RecordInstance[]>,
       plugin_info: {},
       plugin_nested_info: {},
@@ -184,8 +184,16 @@ export const cached_local_store = defineStore("cached", {
           },
         },
       );
-      // I know axios should be able to do this for us, but I didn't have
-      // luck with our internal web server. Any tips?
+      // It seems like some requests automatically decompress this for us
+      // and others do not.
+      // I feel axios should be able to do this for us uniformly, but I didn't
+      // have luck with our internal (ancient) web server and also vite
+      // preview. Any tips?
+      const first_char = new DataView(response.data).getInt8(0);
+      if (first_char == "{".charCodeAt(0)) {
+        let dec = new TextDecoder("utf-8");
+        return JSON.parse(dec.decode(response.data));
+      }
       const decompressed = pako.inflate(response.data, { to: "string" });
       return JSON.parse(decompressed);
     },

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -53,6 +53,10 @@ export interface State {
   queries: Record<string, APIQuery>;
 }
 
+export interface CacheState extends State {
+  file_to_hash: Record<string, string>;
+}
+
 export type Context = [string, number];
 export type FullLoadContext = Context[];
 
@@ -503,10 +507,15 @@ export interface PluginResults {
   nested?: Record<string, PluginResults> | null;
 }
 
+export interface StoreCacheFiles {
+  hash_to_contents: Record<string, FileInfoResponse>;
+  hash_to_file: Record<string, string[]>;
+}
+
 // whatrecord offline cache download -> offline store ``cache`` attribute
 export interface StoreCache {
   pv_relations: Relations;
-  files: Record<string, FileInfoResponse>;
+  files: StoreCacheFiles;
   iocs: Record<string, CachedStartupScript>;
   plugins: Record<string, PluginResults>;
   pv_graphs: Record<string, CachedPVGraph>;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -510,4 +510,5 @@ export interface StoreCache {
   iocs: Record<string, CachedStartupScript>;
   plugins: Record<string, PluginResults>;
   pv_graphs: Record<string, CachedPVGraph>;
+  logs: string[];
 }

--- a/frontend/src/types/stream.ts
+++ b/frontend/src/types/stream.ts
@@ -38,7 +38,7 @@ export interface StreamProtocol {
 }
 
 export interface StreamDeviceRecordAnnotation {
-  protocol_file: string;
+  context: FullLoadContext;
   protocol_name: string;
   protocol_args: string[];
   error?: string;

--- a/frontend/src/views/duplicates.vue
+++ b/frontend/src/views/duplicates.vue
@@ -30,7 +30,7 @@
             query: {
               pattern: data.name,
               record: data.name,
-              use_regex: 'false',
+              regex: 'false',
             },
           }"
           >{{ data.name }}</router-link

--- a/frontend/src/views/gateway.vue
+++ b/frontend/src/views/gateway.vue
@@ -60,7 +60,7 @@
           <router-link
             :to="{
               name: 'whatrec',
-              query: { pattern: data.pattern, record: [], use_regex: 'true' },
+              query: { pattern: data.pattern, record: [], regex: 'true' },
             }"
           >
             {{ data.pattern }}

--- a/frontend/src/views/happi.vue
+++ b/frontend/src/views/happi.vue
@@ -28,7 +28,7 @@
                     query: {
                       pattern: rec.name,
                       record: rec.name,
-                      use_regex: 'false',
+                      regex: 'false',
                     },
                   }"
                 >
@@ -133,7 +133,7 @@
               query: {
                 pattern: data.prefix + '*',
                 record: data.prefix,
-                use_regex: 'false',
+                regex: 'false',
               },
             }"
           >

--- a/frontend/src/views/iocs.vue
+++ b/frontend/src/views/iocs.vue
@@ -297,7 +297,6 @@ export default {
       // Wait until the prop is updated, then update the table DOM:
       await nextTick();
       this.update_table_selection(this.selected_iocs);
-      console.log(this.selected_iocs);
     },
   },
 

--- a/frontend/src/views/iocs.vue
+++ b/frontend/src/views/iocs.vue
@@ -98,7 +98,7 @@
                 query: {
                   pattern: data.record.name,
                   record: data.record.name,
-                  use_regex: 'false',
+                  regex: 'false',
                 },
               }"
               >{{ data.record.name }}</router-link

--- a/frontend/src/views/lcls_epicsarch.vue
+++ b/frontend/src/views/lcls_epicsarch.vue
@@ -104,7 +104,7 @@
                   query: {
                     pattern: data.name,
                     record: data.name,
-                    use_regex: 'false',
+                    regex: 'false',
                   },
                 }"
                 >{{ data.name }}</router-link

--- a/frontend/src/views/logs.vue
+++ b/frontend/src/views/logs.vue
@@ -5,29 +5,25 @@
 </template>
 
 <script lang="ts">
-import axios from "axios";
+import { use_configured_store } from "../stores";
 
 export default {
   name: "ServerLogView",
   components: {},
-  props: {
-    filename: String,
-    line: String,
-  },
+  props: {},
   data() {
     return {
-      log_lines: [],
+      log_lines: [] as string[],
       metadata: null,
     };
   },
+  setup() {
+    const store = use_configured_store();
+    return { store };
+  },
   async mounted() {
-    try {
-      const response = await axios.get("/api/logs/get", { params: {} });
-      this.log_lines = response.data;
-      document.title = "whatrecord? Server logs";
-    } catch (error) {
-      console.error(error);
-    }
+    document.title = "whatrecord? Server logs";
+    this.log_lines = await this.store.get_server_logs();
   },
   updated() {
     const script = document.getElementById("script");

--- a/frontend/src/views/twincat_pytmc.vue
+++ b/frontend/src/views/twincat_pytmc.vue
@@ -13,7 +13,7 @@
         <router-link
           :to="{
             name: 'whatrec',
-            query: { pattern: rec, record: rec, use_regex: 'false' },
+            query: { pattern: rec, record: rec, regex: 'false' },
           }"
         >
           {{ rec }}

--- a/frontend/src/views/whatrec.vue
+++ b/frontend/src/views/whatrec.vue
@@ -85,7 +85,7 @@ export default {
 }
 
 #left {
-  min-width: 15%;
+  min-width: 20%;
   max-width: 20%;
   border-right: 1px dotted;
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -24,6 +24,10 @@ export default defineConfig(({ command, mode }) => {
         ":" +
         env.WHATRECORD_API_PORT,
     );
+  } else {
+    console.error(
+      "Misconfiguration detected - no backend server or cache file set",
+    );
   }
   return {
     define: {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -402,6 +402,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/pako@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@types/pako@npm:2.0.0"
+  checksum: 50240a036b5e6acabbf36ac4dca93ec9e619241f0404da8d401cdb427bec3029833324b8a04c4b1ae2ecbc33422fdec31dbf9f43653d9d07cafb82ace78dfccd
+  languageName: node
+  linkType: hard
+
 "@vitejs/plugin-vue@npm:^4.2.3":
   version: 4.2.3
   resolution: "@vitejs/plugin-vue@npm:4.2.3"
@@ -724,14 +731,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.4.0":
-  version: 1.4.0
-  resolution: "axios@npm:1.4.0"
+"axios@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "axios@npm:1.5.0"
   dependencies:
     follow-redirects: ^1.15.0
     form-data: ^4.0.0
     proxy-from-env: ^1.1.0
-  checksum: 7fb6a4313bae7f45e89d62c70a800913c303df653f19eafec88e56cea2e3821066b8409bc68be1930ecca80e861c52aa787659df0ffec6ad4d451c7816b9386b
+  checksum: e7405a5dbbea97760d0e6cd58fecba311b0401ddb4a8efbc4108f5537da9b3f278bde566deb777935a960beec4fa18e7b8353881f2f465e4f2c0e949fead35be
   languageName: node
   linkType: hard
 
@@ -2247,6 +2254,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pako@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "pako@npm:2.1.0"
+  checksum: 71666548644c9a4d056bcaba849ca6fd7242c6cf1af0646d3346f3079a1c7f4a66ffec6f7369ee0dc88f61926c10d6ab05da3e1fca44b83551839e89edd75a3e
+  languageName: node
+  linkType: hard
+
 "parent-module@npm:^1.0.0":
   version: 1.0.1
   resolution: "parent-module@npm:1.0.1"
@@ -2893,13 +2907,15 @@ __metadata:
   resolution: "whatrecord@workspace:."
   dependencies:
     "@types/d3-graphviz": ^2.6.7
+    "@types/pako": ^2.0.0
     "@vitejs/plugin-vue": ^4.2.3
-    axios: ^1.4.0
+    axios: ^1.5.0
     d3-graphviz: ^5.1.0
     d3-selection: ^3.0.0
     es6-promise: ^4.2.8
     eslint: ^8.47.0
     eslint-plugin-vue: ^9.17.0
+    pako: ^2.1.0
     pinia: ^2.1.6
     primeflex: ^3.3.1
     primeicons: ^6.0.1

--- a/whatrecord/server/common.py
+++ b/whatrecord/server/common.py
@@ -8,7 +8,7 @@ from typing import Any, ClassVar, Dict, Generator, List, Optional, Tuple, Union
 import apischema
 
 from .. import util
-from ..common import (IocMetadata, PVRelations, RecordInstance,
+from ..common import (IocMetadata, IocshScript, PVRelations, RecordInstance,
                       RecordInstanceSummary, ScriptPVRelations, WhatRecord)
 
 logger = logging.getLogger(__name__)
@@ -196,3 +196,17 @@ class PVShortRelationshipResponse:
             script_relations=script_relations,
             # ioc_to_pvs=ioc_to_pvs,
         )
+
+
+@dataclass
+class FileInfoRawResponse:
+    lines: List[str]
+    path: str
+    hash: str
+
+
+@dataclass
+class FileInfoResponse:
+    script: Optional[IocshScript]
+    ioc: Optional[IocMetadata]
+    raw: Optional[FileInfoRawResponse] = None

--- a/whatrecord/server/server.py
+++ b/whatrecord/server/server.py
@@ -242,7 +242,7 @@ class ServerState:
 
         return result
 
-    async def dump_pv_relations(self) -> dict:
+    async def dump_pv_relations(self, *, full: bool = True) -> dict:
         return apischema.serialize(
             PVRelationshipResponse(
                 pv_relations=self.container.pv_relations,
@@ -252,7 +252,11 @@ class ServerState:
             )
         )
 
-    async def dump_pv_graphs(self) -> dict:
+    async def dump_pv_graphs(self, *, full: bool = True) -> dict:
+        if not full:
+            # No graphs at all in partial mode
+            return {}
+
         relation_graphs = {}
         for record in self.container.database:
             if record in self.container.pv_relations:
@@ -289,8 +293,8 @@ class ServerState:
 
         dumped = {
             "plugins": self.dump_plugins(),
-            "pv_graphs": await self.dump_pv_graphs(),
-            "pv_relations": await self.dump_pv_relations(),
+            "pv_graphs": await self.dump_pv_graphs(full=full),
+            "pv_relations": await self.dump_pv_relations(full=full),
         }
 
         if not full:

--- a/whatrecord/server/server.py
+++ b/whatrecord/server/server.py
@@ -295,6 +295,7 @@ class ServerState:
         for item in dumped["iocs"].values():
             item["ioc"].pop("pv_relations")
 
+        dumped["logs"] = self.get_log_messages()
         elapsed = time.monotonic() - t0
         logger.info(
             (
@@ -359,6 +360,14 @@ class ServerState:
     def update_count(self) -> int:
         """The number of times IOCs have been updated."""
         return self._update_count
+
+    def get_log_messages(self) -> list[str]:
+        """Get the server's log messages."""
+        return list(
+            _log_handler.messages
+            if _log_handler is not None
+            else ["Logger not initialized"]
+        )
 
     async def stop(self):
         """Stop any background updates."""
@@ -1030,13 +1039,7 @@ class ServerHandler:
 
     @routes.get("/api/logs/get")
     async def api_logs_get(self, request: web.Request):
-        return web.json_response(
-            list(
-                _log_handler.messages
-                if _log_handler is not None
-                else ["Logger not initialized"]
-            )
-        )
+        return web.json_response(self.state.get_log_messages())
 
     @routes.get("/api/pv/relations")
     async def api_pv_get_relations(self, request: web.Request):

--- a/whatrecord/shell.py
+++ b/whatrecord/shell.py
@@ -25,7 +25,8 @@ from .autosave import AutosaveState
 from .common import (AnyPath, FullLoadContext, IocMetadata, IocshCmdArgs,
                      IocshResult, IocshScript, LoadContext, MutableLoadContext,
                      PVRelations, RecordDefinitionAndInstance, RecordInstance,
-                     ShellStateHandler, WhatRecord, time_context)
+                     ShellStateHandler, StringWithContext, WhatRecord,
+                     time_context)
 from .db import Database, DatabaseLoadFailure, RecordType
 from .format import FormatContext
 from .iocsh import parse_iocsh_line
@@ -592,11 +593,22 @@ class ShellState(ShellStateHandler):
             context=self.get_load_context()
         )
 
-        # TODO: add option to annotate all records without requiring
-        # per-record whatrecord queries
-        # if self.annotate_all:
-        #     for record in db.records.values():
-        #         record.metadata.update(self.annotate_record(record))
+        for record in db.records.values():
+            # TODO: maybe add option to annotate all records without requiring
+            # per-record whatrecord queries
+            # if self.annotate_all:
+            #       record.metadata.update(self.annotate_record(record))
+
+            # StreamDevice loading is context-sensitive: the current working
+            # directory at the time of evaluation may be used to find
+            # the protocol file.  Special case this here and pre-annotate.
+            annotation = self.streamdevice.annotate_record(record)
+            if annotation:
+                key = StringWithContext(
+                    self.streamdevice.metadata_key,
+                    context=record.context,
+                )
+                record.metadata[key] = annotation
 
         return {
             "context": [LoadContext(str(filename), 0)],
@@ -609,6 +621,10 @@ class ShellState(ShellStateHandler):
         """Hook to annotate a record after being loaded."""
         result = {}
         for handler in self.sub_handlers:
+            if handler is self.streamdevice:
+                # This is handled as the database is loaded.
+                continue
+
             try:
                 annotation = handler.annotate_record(record)
             except Exception:

--- a/whatrecord/shell.py
+++ b/whatrecord/shell.py
@@ -606,7 +606,7 @@ class ShellState(ShellStateHandler):
             if annotation:
                 key = StringWithContext(
                     self.streamdevice.metadata_key,
-                    context=record.context,
+                    context=(),
                 )
                 record.metadata[key] = annotation
 

--- a/whatrecord/tests/test_serialization.py
+++ b/whatrecord/tests/test_serialization.py
@@ -115,6 +115,7 @@ init_args_by_type = {
     Optional[common.RecordDefinitionAndInstance]: None,
     Optional[common.RecordInstance]: None,
     Optional[common.RecordType]: None,
+    Optional[common.IocshScript]: None,
     Union[snl.Declarator, snl.Variable]: snl.Variable(context=[], name="test"),
     snl.OptionalExpression: None,
     blark.dependency_store.PlcProjectMetadata: None,  # non-serialized


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Server logs visible on serverless mode
* File viewing working on serverless mode
* To potentially revert or make configurable: using [hash mode in vue-router](https://router.vuejs.org/guide/essentials/history-mode.html#Hash-Mode) to avoid changes to our old web servers
* Had issues with axios decompressing `.json.gz` on pswww (perhaps due to my own lack of knowledge); reverted to using a separate library for decompression which should work in all cases
* Adds plugin-only mode, used in the current deployment

TODO:
- [ ] Test that I didn't break viewing logs by way of the server store (`logs.vue`)

## Motivation and Context
* Conference is coming up
* Test deployment of serverless "plugin-only" thing is on pswww for our team to use

## How Has This Been Tested?
* Interactively
* Some in the test suite

## Where Has This Been Documented?
PR

## Screenshots (if appropriate):
<img width="640" alt="image" src="https://github.com/pcdshub/whatrecord/assets/5139267/b059f5eb-bd56-452a-b520-40ba76ee3778">
<img width="1024" alt="image" src="https://github.com/pcdshub/whatrecord/assets/5139267/4ec2b839-8a5c-438b-9b86-d77387f14df7">
